### PR TITLE
fix: removes DefaultWindowRoutes method call after setting layout

### DIFF
--- a/src/VideoWindowing/HdWp4k401cController.cs
+++ b/src/VideoWindowing/HdWp4k401cController.cs
@@ -197,7 +197,7 @@ namespace PepperDash.Essentials.DM.VideoWindowing
             _HdWpChassis.HdWpWindowLayout.Layout = _layoutType;
 
             //Reset AV Routes when SetWindowLayout is called
-            DefaultWindowRoutes();
+            //DefaultWindowRoutes();
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request includes a minor change to the `SetWindowLayout` method in `src/VideoWindowing/HdWp4k401cController.cs`. The change comments out the call to `DefaultWindowRoutes()` to prevent resetting AV routes when the window layout is set.