### PR TITLE
feat: Add VideoSyncFeedback for auto-route-on-sync support

### DIFF
--- a/src/Chassis/DmChassisController.cs
+++ b/src/Chassis/DmChassisController.cs
@@ -17,12 +17,13 @@ using PepperDash.Essentials.Core.Bridges;
 using PepperDash.Essentials.DM.Config;
 using PepperDash.Essentials.DM.Routing;
 using PepperDash.Essentials.Core.Config;
+using PepperDash.Core.Logging;
 
 namespace PepperDash.Essentials.DM
 {
     /// <summary>
     /// Builds a controller for basic DM-RMCs with Com and IR ports and no control functions
-    /// 
+    ///
     /// </summary>
     [Description("Wrapper class for all DM-MD chassis variants from 8x8 to 32x32")]
     public class DmChassisController : CrestronGenericBridgeableBaseDevice, IDmSwitchWithEndpointOnlineFeedback, IRoutingNumericWithFeedback, IMatrixRouting
@@ -156,7 +157,7 @@ namespace PepperDash.Essentials.DM
                 // add the cards and port names
                 foreach (var kvp in properties.InputSlots)
                     controller.AddInputCard(kvp.Value, kvp.Key);
-                
+
                 foreach (var kvp in properties.OutputSlots)
                     controller.AddOutputCard(kvp.Value, kvp.Key);
 
@@ -183,7 +184,7 @@ namespace PepperDash.Essentials.DM
                 if (!string.IsNullOrEmpty(properties.NoRouteText))
                 {
                     controller.NoRouteText = properties.NoRouteText;
-                    Debug.LogDebug(controller, "Setting No Route Text value to: {0}", controller.NoRouteText);                   
+                    Debug.LogDebug(controller, "Setting No Route Text value to: {0}", controller.NoRouteText);
                 }
                 else
                 {
@@ -202,7 +203,7 @@ namespace PepperDash.Essentials.DM
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="key"></param>
         /// <param name="name"></param>
@@ -294,7 +295,7 @@ namespace PepperDash.Essentials.DM
                         return NoRouteText;
                     });
                     OutputEndpointOnlineFeedbacks[tempX] = new BoolFeedback(() => Chassis.Outputs[tempX].EndpointOnlineFeedback);
-                    
+
                     OutputDisabledByHdcpFeedbacks[tempX] = new BoolFeedback(() => {
                         var output = Chassis.Outputs[tempX];
 
@@ -372,7 +373,7 @@ namespace PepperDash.Essentials.DM
                     VideoInputSyncFeedbacks[tempX] = new BoolFeedback(() => {
                         if (Chassis.Inputs[tempX].VideoDetectedFeedback != null)
                             return Chassis.Inputs[tempX].VideoDetectedFeedback.BoolValue;
-                        
+
                         return false;
                     });
                     InputNameFeedbacks[tempX] = new StringFeedback(() => {
@@ -456,7 +457,7 @@ namespace PepperDash.Essentials.DM
                         {
                             Debug.LogInformation(this, "The Input Card in slot: {0} supports HDCP 2.  Please update the configuration value in the inputCardSupportsHdcp2 object to true. Error: {1}", tempX, iopex);
                             return 0;
-                        }   
+                        }
                     });
                     InputStreamCardStateFeedbacks[tempX] = new IntFeedback(() =>
                     {
@@ -491,7 +492,7 @@ namespace PepperDash.Essentials.DM
 
         private void ChassisOnBaseEvent(GenericBase device, BaseEventArgs args)
         {
-            
+
         }
 
         private void RegisterForInputResolutionFeedback(IVideoAttributesBasic input, uint number, RoutingInputPortWithVideoStatuses inputPort)
@@ -505,15 +506,13 @@ namespace PepperDash.Essentials.DM
 
             input.VideoAttributes.AttributeChange += (sender, args) =>
             {
-                Debug.LogDebug(this, "Input {0} resolution updated", number);
-
-                Debug.LogDebug(this, "Updating resolution feedback for input {0}", number);
-                inputPort.VideoStatus.VideoResolutionFeedback.FireUpdate();
+                this.LogInformation("Updating feedback for input {0}", number);
+                inputPort.VideoStatus.FireAll();
             };
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="type"></param>
         /// <param name="number"></param>
@@ -531,6 +530,7 @@ namespace PepperDash.Essentials.DM
                 {
                     inputCard = new DmcHd(number, Chassis);
                     var card = inputCard as DmcHd;
+
                     AddHdmiInCardPorts(number, card.HdmiInput, card.HdmiInput);
                 }
                     break;
@@ -585,7 +585,7 @@ namespace PepperDash.Essentials.DM
                     AddDmInCardPorts(number, null, card.DmInput);
                     break;
                 }
-                    
+
                 case "dmc4kc":
                 {
                     inputCard = new Dmc4kC(number, Chassis);
@@ -593,7 +593,7 @@ namespace PepperDash.Essentials.DM
                     AddDmInCardPorts(number, card.DmInput, card.DmInput);
                     break;
                 }
-                    
+
                 case "dmc4kcdsp":
                 {
                     inputCard = new Dmc4kCDsp(number, Chassis);
@@ -601,7 +601,7 @@ namespace PepperDash.Essentials.DM
                     AddDmInCardPorts(number, card.DmInput, card.DmInput);
                     break;
                 }
-                    
+
                 case "dmc4kzc":
                 {
                     inputCard = new Dmc4kzC(number, Chassis);
@@ -609,7 +609,7 @@ namespace PepperDash.Essentials.DM
                     AddDmInCardPorts(number, card.DmInput, card.DmInput);
                     break;
                 }
-                   
+
                 case "dmc4kzcdsp":
                 {
                     inputCard = new Dmc4kzCDsp(number, Chassis);
@@ -617,7 +617,7 @@ namespace PepperDash.Essentials.DM
                     AddDmInCardPorts(number, card.DmInput, card.DmInput);
                     break;
                 }
-                    
+
                 case "dmccat":
                 {
                     inputCard = new DmcCat(number, Chassis);
@@ -796,7 +796,7 @@ namespace PepperDash.Essentials.DM
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="type"></param>
         /// <param name="number"></param>
@@ -982,6 +982,21 @@ namespace PepperDash.Essentials.DM
                 Debug.LogDebug(this, "card {0} supports IVideoAttributesBasic", cardNum);
                 var statusFuncs = new VideoStatusFuncsWrapper
                 {
+                    VideoSyncFeedbackFunc = () =>
+                    {
+                        var videoSync = false;
+                        switch (videoAttributesBasic)
+                        {
+                            case EndpointHdmiInput hdmi:
+                                videoSync = hdmi.SyncDetectedFeedback.BoolValue;
+                                break;
+                            case EndpointDmInputStream dm:
+                                videoSync = dm.SyncDetectedFeedback.BoolValue;
+                                break;
+                        }
+
+                        return videoSync;
+                    },
                     VideoResolutionFeedbackFunc = () =>
                     {
                         var resolution = videoAttributesBasic.VideoAttributes.GetVideoResolutionString();
@@ -1040,7 +1055,7 @@ namespace PepperDash.Essentials.DM
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         void AddVolumeControl(uint number, Audio.Output audio)
         {
@@ -1205,7 +1220,7 @@ namespace PepperDash.Essentials.DM
             if (newEvent != null) newEvent(this, e);
         }
 
-        /// 
+        ///
         /// </summary>
         void Chassis_DMOutputChange(Switch device, DMOutputEventArgs args)
         {
@@ -1238,7 +1253,7 @@ namespace PepperDash.Essentials.DM
                 }
                 case DMOutputEventIds.VideoOutEventId:
                 {
-                    
+
                     var inputNumber = Chassis.Outputs[output].VideoOutFeedback == null ? 0 : Chassis.
                     Outputs[output].VideoOutFeedback.Number;
 
@@ -1331,7 +1346,7 @@ namespace PepperDash.Essentials.DM
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="pnt"></param>
         void StartOffTimer(PortNumberType pnt)
@@ -1400,7 +1415,7 @@ namespace PepperDash.Essentials.DM
             //var inCard = input == 0 ? null : Chassis.Inputs[input];
             //var outCard = input == 0 ? null : Chassis.Outputs[output];
 
-            // NOTE THAT BITWISE COMPARISONS - TO CATCH ALL ROUTING TYPES 
+            // NOTE THAT BITWISE COMPARISONS - TO CATCH ALL ROUTING TYPES
             if ((sigType & eRoutingSignalType.Video) == eRoutingSignalType.Video)
             {
                 Chassis.VideoEnter.BoolValue = true;
@@ -1424,7 +1439,7 @@ namespace PepperDash.Essentials.DM
             }
 
             if ((sigType & eRoutingSignalType.UsbOutput) == eRoutingSignalType.UsbOutput)
-                
+
             {
                Chassis.USBEnter.BoolValue = true;
                 if (inputSelector == null && output != null)
@@ -1621,10 +1636,10 @@ namespace PepperDash.Essentials.DM
             Debug.LogDebug("Port is HdmiInputWithCec");
 
             var hdmiInPortWCec = port as HdmiInputWithCEC;
-            
-            
+
+
             SetHdcpStateAction(PropertiesConfig.InputSlotSupportsHdcp2[ioSlot], hdmiInPortWCec, joinMap.HdcpSupportState.JoinNumber + ioSlotJoin, trilist);
-            
+
 
             InputCardHdcpStateFeedbacks[ioSlot].LinkInputSig(
                 trilist.UShortInput[joinMap.HdcpSupportState.JoinNumber + ioSlotJoin]);
@@ -1808,7 +1823,7 @@ namespace PepperDash.Essentials.DM
 
             //added in case the InputSlotSupportsHdcp2 section isn't included in the config, or this slot is left out.
             //if the key isn't in the dictionary, supportsHdcp2 will be false
-            
+
             if(!PropertiesConfig.InputSlotSupportsHdcp2.TryGetValue(ioSlot, out supportsHdcp2))
             {
                 Debug.LogInformation(this, "Input Slot Supports HDCP2 setting not found for slot {0}. Setting to false. Program may not function as intended.",
@@ -2034,12 +2049,12 @@ namespace PepperDash.Essentials.DM
                     {
                         if (s == 0)
                         {
-                            Debug.LogVerbose(this, "Join {0} value {1} Setting HdcpSupport to off", join, s); 
+                            Debug.LogVerbose(this, "Join {0} value {1} Setting HdcpSupport to off", join, s);
                             port.HdcpSupportOff();
                         }
                         else if (s > 0)
                         {
-                            Debug.LogVerbose(this, "Join {0} value {1} Setting HdcpSupport to on", join, s); 
+                            Debug.LogVerbose(this, "Join {0} value {1} Setting HdcpSupport to on", join, s);
                             port.HdcpSupportOn();
                         }
                     });
@@ -2049,7 +2064,7 @@ namespace PepperDash.Essentials.DM
                 trilist.SetUShortSigAction(join,
                         u =>
                         {
-                            Debug.LogVerbose(this, "Join {0} value {1} Setting HdcpReceiveCapability to: {2}", join, u, (eHdcpCapabilityType)u); 
+                            Debug.LogVerbose(this, "Join {0} value {1} Setting HdcpReceiveCapability to: {2}", join, u, (eHdcpCapabilityType)u);
                             port.HdcpReceiveCapability = (eHdcpCapabilityType)u;
                         });
             }
@@ -2211,9 +2226,9 @@ namespace PepperDash.Essentials.DM
         public DmChassisControllerFactory()
         {
             MinimumEssentialsFrameworkVersion = "2.4.5";
-            TypeNames = new List<string>() { "dmmd8x8", "dmmd8x8rps", "dmmd8x8cpu3", "dmmd8x8cpu3rps", 
-                "dmmd16x16", "dmmd16x16rps", "dmmd16x16cpu3", "dmmd16x16cpu3rps", 
-                "dmmd32x32", "dmmd32x32rps", "dmmd32x32cpu3", "dmmd32x32cpu3rps", 
+            TypeNames = new List<string>() { "dmmd8x8", "dmmd8x8rps", "dmmd8x8cpu3", "dmmd8x8cpu3rps",
+                "dmmd16x16", "dmmd16x16rps", "dmmd16x16cpu3", "dmmd16x16cpu3rps",
+                "dmmd32x32", "dmmd32x32rps", "dmmd32x32cpu3", "dmmd32x32cpu3rps",
                 "dmmd64x64", "dmmd128x128" };
         }
 

--- a/src/Chassis/DmChassisController.cs
+++ b/src/Chassis/DmChassisController.cs
@@ -984,18 +984,10 @@ namespace PepperDash.Essentials.DM
                 {
                     VideoSyncFeedbackFunc = () =>
                     {
-                        var videoSync = false;
-                        switch (videoAttributesBasic)
-                        {
-                            case EndpointHdmiInput hdmi:
-                                videoSync = hdmi.SyncDetectedFeedback.BoolValue;
-                                break;
-                            case EndpointDmInputStream dm:
-                                videoSync = dm.SyncDetectedFeedback.BoolValue;
-                                break;
-                        }
-
-                        return videoSync;
+                        // Use chassis input's VideoDetectedFeedback directly for reliable sync detection
+                        if (Chassis.Inputs[cardNum].VideoDetectedFeedback != null)
+                            return Chassis.Inputs[cardNum].VideoDetectedFeedback.BoolValue;
+                        return false;
                     },
                     VideoResolutionFeedbackFunc = () =>
                     {
@@ -1122,6 +1114,17 @@ namespace PepperDash.Essentials.DM
                         {
                             Debug.LogVerbose(this, "DM Input {0} VideoDetectedEventId", args.Number);
                             VideoInputSyncFeedbacks[args.Number].FireUpdate();
+                            
+                            // Also fire the routing port's VideoSyncFeedback for subscribers (e.g., auto-routing on sync)
+                            var syncInputPort =
+                                InputPorts.OfType<RoutingInputPortWithVideoStatuses>()
+                                    .FirstOrDefault((ip) => ip.Key.Contains(String.Format("inputCard{0}", args.Number)));
+
+                            if (syncInputPort != null)
+                            {
+                                Debug.LogDebug(this, "Firing VideoSyncFeedback for input {0}", args.Number);
+                                syncInputPort.VideoStatus.VideoSyncFeedback.FireUpdate();
+                            }
                             break;
                         }
                     case DMInputEventIds.InputNameEventId:
@@ -1186,7 +1189,7 @@ namespace PepperDash.Essentials.DM
                     {
                         Debug.LogDebug(this, "Input {0} resolution updated", args.Number);
                         var inputPort =
-                            InputPorts.Cast<RoutingInputPortWithVideoStatuses>()
+                            InputPorts.OfType<RoutingInputPortWithVideoStatuses>()
                                 .FirstOrDefault((ip) => ip.Key.Contains(String.Format("inputCard{0}", args.Number)));
 
                         if (inputPort != null)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.0.0-local</Version>
+    <Version>1.5.5-local</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Authors>PepperDash Technology</Authors>
     <Company>PepperDash Technology</Company>    

--- a/src/Endpoints/Transmitters/MockDmTxController.cs
+++ b/src/Endpoints/Transmitters/MockDmTxController.cs
@@ -1,0 +1,171 @@
+using System.Collections.Generic;
+using Crestron.SimplSharpPro.DeviceSupport;
+using Newtonsoft.Json;
+using PepperDash.Core;
+using PepperDash.Essentials.Core;
+using PepperDash.Essentials.Core.Bridges;
+using PepperDash.Essentials.Core.Config;
+using Serilog.Events;
+
+namespace PepperDash.Essentials.DM
+{
+    /// <summary>
+    /// A software-only mock of a single-HDMI-input DM transmitter (e.g. DM-TX-4K-100-C-1G) with no dependency
+    /// on real Crestron DM hardware. Useful for testing code that consumes <see cref="VideoStatusOutputs"/>
+    /// (such as auto-route-on-sync logic) when physical hardware isn't available.
+    /// </summary>
+    /// <remarks>
+    /// Feedback states can be manipulated at runtime from the console using devjson commands, e.g.:
+    /// devjson:1 {"deviceKey":"mockTx1", "methodName":"SetHdmiSyncDetected", "params": [true]}
+    /// </remarks>
+    [Description("Mock single-HDMI-input DM transmitter for testing without hardware")]
+    public class MockDmTxController : EssentialsBridgeableDevice, IRoutingInputsOutputs, IOnline
+    {
+        private bool _isOnline = true;
+        private bool _hdmiSyncDetected;
+        private bool _hdmiHdcpActive;
+        private string _hdmiHdcpState = "None";
+        private string _hdmiResolution = "1920x1080";
+
+        /// <inheritdoc />
+        public BoolFeedback IsOnline { get; private set; }
+
+        /// <summary>
+        /// The HDMI input, including video status feedback that can be manipulated for testing.
+        /// </summary>
+        public RoutingInputPortWithVideoStatuses HdmiIn { get; private set; }
+
+        /// <summary>
+        /// The DM output port
+        /// </summary>
+        public RoutingOutputPort DmOut { get; private set; }
+
+        /// <inheritdoc />
+        public RoutingPortCollection<RoutingInputPort> InputPorts { get; private set; }
+
+        /// <inheritdoc />
+        public RoutingPortCollection<RoutingOutputPort> OutputPorts { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the MockDmTxController class
+        /// </summary>
+        /// <param name="key">The device key</param>
+        /// <param name="name">The device name</param>
+        public MockDmTxController(string key, string name)
+            : base(key, name)
+        {
+            IsOnline = new BoolFeedback("IsOnlineFeedback", () => _isOnline);
+
+            var hdmiInFuncs = new VideoStatusFuncsWrapper
+            {
+                HasVideoStatusFunc = () => true,
+                HdcpActiveFeedbackFunc = () => _hdmiHdcpActive,
+                HdcpStateFeedbackFunc = () => _hdmiHdcpState,
+                VideoResolutionFeedbackFunc = () => _hdmiResolution,
+                VideoSyncFeedbackFunc = () => _hdmiSyncDetected
+            };
+
+            HdmiIn = new RoutingInputPortWithVideoStatuses(DmPortName.HdmiIn1,
+                eRoutingSignalType.Audio | eRoutingSignalType.Video, eRoutingPortConnectionType.Hdmi, 1, this,
+                hdmiInFuncs);
+
+            DmOut = new RoutingOutputPort(DmPortName.DmOut, eRoutingSignalType.Audio | eRoutingSignalType.Video,
+                eRoutingPortConnectionType.DmCat, null, this);
+
+            InputPorts = new RoutingPortCollection<RoutingInputPort> { HdmiIn };
+            OutputPorts = new RoutingPortCollection<RoutingOutputPort> { DmOut };
+        }
+
+        /// <summary>
+        /// Sets the simulated HDMI sync-detected state and fires <see cref="VideoStatusOutputs.VideoSyncFeedback"/>
+        /// so any subscribers (e.g. auto-route-on-sync logic) react as though reported by real hardware.
+        /// </summary>
+        /// <param name="syncDetected">true to simulate sync detected, false to simulate no sync</param>
+        public void SetHdmiSyncDetected(bool syncDetected)
+        {
+            _hdmiSyncDetected = syncDetected;
+            HdmiIn.VideoStatus.VideoSyncFeedback.FireUpdate();
+        }
+
+        /// <summary>
+        /// Sets the simulated HDCP active state on the HDMI input.
+        /// </summary>
+        /// <param name="hdcpActive">true to simulate HDCP active</param>
+        public void SetHdmiHdcpActive(bool hdcpActive)
+        {
+            _hdmiHdcpActive = hdcpActive;
+            HdmiIn.VideoStatus.HdcpActiveFeedback.FireUpdate();
+        }
+
+        /// <summary>
+        /// Sets the simulated HDCP state string on the HDMI input (e.g. "1.4", "2.2", "None").
+        /// </summary>
+        /// <param name="hdcpState">the HDCP state to report</param>
+        public void SetHdmiHdcpState(string hdcpState)
+        {
+            _hdmiHdcpState = hdcpState;
+            HdmiIn.VideoStatus.HdcpStateFeedback.FireUpdate();
+        }
+
+        /// <summary>
+        /// Sets the simulated resolution string reported for the HDMI input (e.g. "1920x1080@60Hz").
+        /// </summary>
+        /// <param name="resolution">the resolution string to report</param>
+        public void SetHdmiResolution(string resolution)
+        {
+            _hdmiResolution = resolution;
+            HdmiIn.VideoStatus.VideoResolutionFeedback.FireUpdate();
+        }
+
+        /// <summary>
+        /// Sets the simulated online/offline state of the transmitter.
+        /// </summary>
+        /// <param name="isOnline">true to simulate online, false to simulate offline</param>
+        public void SetOnline(bool isOnline)
+        {
+            _isOnline = isOnline;
+            IsOnline.FireUpdate();
+        }
+
+        /// <inheritdoc />
+        public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+        {
+            var joinMap = new DmTxControllerJoinMap(joinStart);
+
+            var joinMapSerialized = JoinMapHelper.GetSerializedJoinMapForDevice(joinMapKey);
+            if (!string.IsNullOrEmpty(joinMapSerialized))
+                joinMap = JsonConvert.DeserializeObject<DmTxControllerJoinMap>(joinMapSerialized);
+
+            if (bridge != null)
+                bridge.AddJoinMap(Key, joinMap);
+
+            trilist.StringInput[joinMap.Name.JoinNumber].StringValue = Name;
+
+            IsOnline.LinkInputSig(trilist.BooleanInput[joinMap.IsOnline.JoinNumber]);
+            HdmiIn.VideoStatus.VideoSyncFeedback.LinkInputSig(trilist.BooleanInput[joinMap.VideoSyncStatus.JoinNumber]);
+            HdmiIn.VideoStatus.VideoResolutionFeedback.LinkInputSig(trilist.StringInput[joinMap.CurrentInputResolution.JoinNumber]);
+        }
+    }
+
+    /// <summary>
+    /// Factory for <see cref="MockDmTxController"/>
+    /// </summary>
+    public class MockDmTxControllerFactory : EssentialsPluginDeviceFactory<MockDmTxController>
+    {
+        /// <summary>
+        /// Initializes a new instance of the MockDmTxControllerFactory class
+        /// </summary>
+        public MockDmTxControllerFactory()
+        {
+            MinimumEssentialsFrameworkVersion = "2.7.0";
+            TypeNames = new List<string> { "mockdmtx", "mockdmtx4k100c1g" };
+        }
+
+        /// <inheritdoc />
+        public override EssentialsDevice BuildDevice(DeviceConfig dc)
+        {
+            Debug.LogMessage(LogEventLevel.Debug, "Factory Attempting to create new Mock DM TX Device");
+            return new MockDmTxController(dc.Key, dc.Name);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds VideoSyncFeedback support and auto-route-on-sync functionality for DM chassis controllers.

## Changes
- Added `VideoSyncFeedbackFunc` using `Chassis.Inputs[cardNum].VideoDetectedFeedback` for sync detection
- Added `FireUpdate()` call to propagate sync changes to subscribers
- Fixed casting issues using `OfType<>` instead of `Cast<>`

## Discussion Points
⚠️ **Requires Review**: See [Issue #30](https://github.com/PepperDash/PepperDash.Essentials.DM/issues/30) for discussion on VideoSyncFeedback source selection:

| Chassis Type | Current Source | Potentially Better Source |
|--------------|----------------|---------------------------|
| Older DM chassis | Chassis controller | Endpoint (TX device) |
| CPU3 models | Chassis controller | Chassis controller ✓ |

The current implementation uses chassis controller feedback for all models. This may need to be differentiated based on chassis generation, similar to how `OutputEndpointOnlineFeedbacks` already handles CPU3 vs non-CPU3 behavior.

## Testing
- [ ] Test with older DM chassis (non-CPU3)
- [ ] Test with CPU3 chassis models
- [ ] Verify auto-route-on-sync triggers correctly with wallplate sync

## Related
- Closes #30 (pending discussion resolution)