### PR TITLE
feat!: migrate plugin to Essentials v3 (net8)

### DIFF
--- a/PepperDash.Essentials.DM.4Series.sln
+++ b/PepperDash.Essentials.DM.4Series.sln
@@ -5,19 +5,50 @@ VisualStudioVersion = 17.7.34202.233
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PepperDash.Essentials.DM", "src\PepperDash.Essentials.DM.csproj", "{54D4F245-F365-4D49-BB58-55DF5E6C591B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PepperDash.Essentials.DM.Tests", "tests\PepperDash.Essentials.DM.Tests.csproj", "{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Debug|x64.Build.0 = Debug|Any CPU
+		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Debug|x86.Build.0 = Debug|Any CPU
 		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Release|x64.ActiveCfg = Release|Any CPU
+		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Release|x64.Build.0 = Release|Any CPU
+		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Release|x86.ActiveCfg = Release|Any CPU
+		{54D4F245-F365-4D49-BB58-55DF5E6C591B}.Release|x86.Build.0 = Release|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Debug|x64.Build.0 = Debug|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Debug|x86.Build.0 = Debug|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Release|x64.ActiveCfg = Release|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Release|x64.Build.0 = Release|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Release|x86.ActiveCfg = Release|Any CPU
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C02BB6AD-B844-4BB7-8612-7C1AD8B44A8A} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1F097FF5-49CA-4AC8-9CA9-A09BC6884B04}

--- a/src/AirMedia/AirMediaController.cs
+++ b/src/AirMedia/AirMediaController.cs
@@ -123,7 +123,7 @@ namespace PepperDash.Essentials.DM.AirMedia
             HdmiVideoSyncDetectedFeedback = new BoolFeedback(() => false);
         }
 
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
             if (PropertiesConfig.AutoSwitchingEnabled)
                 AirMedia.DisplayControl.EnableAutomaticRouting();
@@ -371,7 +371,7 @@ namespace PepperDash.Essentials.DM.AirMedia
     {
         public AirMediaControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "3.0.0";
             TypeNames = new List<string>() { "am200", "am300", "am3200" };
         }
 

--- a/src/Chassis/DmCardAudioOutput.cs
+++ b/src/Chassis/DmCardAudioOutput.cs
@@ -12,6 +12,9 @@ namespace PepperDash.Essentials.DM
 {
     public class DmCardAudioOutputController : IBasicVolumeWithFeedback
     {
+        public string Key { get; private set; }
+        public string Name { get; private set; }
+
         public Audio.Output Output { get; private set; }
 
         public IntFeedback VolumeLevelFeedback { get; private set; }
@@ -23,6 +26,8 @@ namespace PepperDash.Essentials.DM
 
         public DmCardAudioOutputController(Audio.Output output)
         {
+            Key = "dmCardAudioOutput";
+            Name = "DM Card Audio Output";
             Output = output;
             VolumeLevelFeedback = new IntFeedback(() => Output.VolumeFeedback.UShortValue);
             MuteFeedback = new BoolFeedback(() => IsMuted);

--- a/src/Chassis/DmChassisController.cs
+++ b/src/Chassis/DmChassisController.cs
@@ -27,6 +27,8 @@ namespace PepperDash.Essentials.DM
     public class DmChassisController : CrestronGenericBridgeableBaseDevice, IDmSwitchWithEndpointOnlineFeedback, IRoutingNumericWithFeedback, IMatrixRouting
     {
         private const string NonePortKey = "inputCard0--None";
+        // On an 8x8 chassis the USB slot numbers for outputs start at 17 (inputs 1-8, outputs 17-24).
+        private const uint Usb8x8OutputSlotOffset = 16;
         public DMChassisPropertiesConfig PropertiesConfig { get; set; }
 
         public Switch Chassis { get; private set; }
@@ -1370,7 +1372,7 @@ namespace PepperDash.Essentials.DM
 
             var output = outputSelector as DMOutput;
 
-            // In Essentials v3, eRoutingSignalType.UsbInput and UsbOutput were merged into Usb.
+            // In Essentials v3, eRoutingSignalType.UsbInput and eRoutingSignalType.UsbOutput were merged into eRoutingSignalType.Usb.
             var isUsb = (sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb;
 
             if (output == null && !isUsb)
@@ -1487,7 +1489,7 @@ namespace PepperDash.Essentials.DM
 
             DMInputOutputBase dmCard;
 
-            //Routing Input to Input or Output to Input (USB input-side routing)
+            //Routing for USB input-side: routes a USB source to a switcher input slot
             if ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb)
             {
                 Debug.LogVerbose(this, "Executing USB Input switch.\r\n in:{0} output: {1}", inputSelector, outputSelector);
@@ -1497,7 +1499,7 @@ namespace PepperDash.Essentials.DM
 
                     if (chassisSize == 8)
                     {
-                        outputIndex = (uint) inputSelector - 16;
+                        outputIndex = (uint) inputSelector - Usb8x8OutputSlotOffset;
                     }
                     else
                     {
@@ -1545,7 +1547,7 @@ namespace PepperDash.Essentials.DM
 
                 if (chassisSize == 8)
                 {
-                    outputIndex = (uint) inputSelector - 16;
+                    outputIndex = (uint) inputSelector - Usb8x8OutputSlotOffset;
                 }
                 else
                 {

--- a/src/Chassis/DmChassisController.cs
+++ b/src/Chassis/DmChassisController.cs
@@ -412,7 +412,7 @@ namespace PepperDash.Essentials.DM
                             }
                             if (inputCard.Card is Dmc4kHdDspBase)
                             {
-                                if (PropertiesConfig.InputSlotSupportsHdcp2[tempX])
+                                if (PropertiesConfig.InputSlotSupportsHdcp2.TryGetValue(tempX, out var hdDspSupportsHdcp2) && hdDspSupportsHdcp2)
                                 {
                                     InputCardHdcpCapabilityTypes[tempX] = eHdcpCapabilityType.Hdcp2_2Support;
                                     return (int)(inputCard.Card as Dmc4kHdDspBase).HdmiInput.HdcpReceiveCapability;
@@ -426,7 +426,7 @@ namespace PepperDash.Essentials.DM
 
                             if (inputCard.Card is Dmc4kCBase)
                             {
-                                if (PropertiesConfig.InputSlotSupportsHdcp2[tempX])
+                                if (PropertiesConfig.InputSlotSupportsHdcp2.TryGetValue(tempX, out var c4kCSupportsHdcp2) && c4kCSupportsHdcp2)
                                 {
                                     InputCardHdcpCapabilityTypes[tempX] = eHdcpCapabilityType.HdcpAutoSupport;
                                     return (int)(inputCard.Card as Dmc4kCBase).DmInput.HdcpReceiveCapability;
@@ -438,7 +438,7 @@ namespace PepperDash.Essentials.DM
                             }
                             if (inputCard.Card is Dmc4kCDspBase)
                             {
-                                if (PropertiesConfig.InputSlotSupportsHdcp2[tempX])
+                                if (PropertiesConfig.InputSlotSupportsHdcp2.TryGetValue(tempX, out var cDspSupportsHdcp2) && cDspSupportsHdcp2)
                                 {
                                     InputCardHdcpCapabilityTypes[tempX] = eHdcpCapabilityType.HdcpAutoSupport;
                                     return (int)(inputCard.Card as Dmc4kCDspBase).DmInput.HdcpReceiveCapability;
@@ -1370,10 +1370,10 @@ namespace PepperDash.Essentials.DM
 
             var output = outputSelector as DMOutput;
 
-            var isUsbInput = (sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb;
-            var isUsbOutput = (sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb;
+            // In Essentials v3, eRoutingSignalType.UsbInput and UsbOutput were merged into Usb.
+            var isUsb = (sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb;
 
-            if (output == null && !(isUsbOutput || isUsbInput))
+            if (output == null && !isUsb)
             {
                 Debug.LogInformation(this, "Unable to execute switch for inputSelector {0} to outputSelector {1}", inputSelector,
                     outputSelector);
@@ -1487,7 +1487,7 @@ namespace PepperDash.Essentials.DM
 
             DMInputOutputBase dmCard;
 
-            //Routing Input to Input or Output to Input
+            //Routing Input to Input or Output to Input (USB input-side routing)
             if ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb)
             {
                 Debug.LogVerbose(this, "Executing USB Input switch.\r\n in:{0} output: {1}", inputSelector, outputSelector);
@@ -1513,46 +1513,55 @@ namespace PepperDash.Essentials.DM
                 ExecuteSwitch(dmCard, Chassis.Inputs[outputSelector], sigType);
                 return;
             }
-            if ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb)
-            {
-                Debug.LogVerbose(this, "Executing USB Output switch.\r\n in:{0} output: {1}", inputSelector, outputSelector);
-
-                //routing Output to Output or Input to Output
-                if (inputSelector > chassisSize)
-                {
-                    //wanting to route an output to an output. Subtract chassis size and get output, unless it's 8x8
-                    //need this to determine USB routing values
-                    //8x8 -> 1-8 is inputs 1-8, 17-24 is outputs 1-8
-                    //16x16 1-16 is inputs 1-16, 17-32 is outputs 1-16
-                    //32x32 1-32 is inputs 1-32, 33-64 is outputs 1-32
-                    uint outputIndex;
-
-                    if (chassisSize == 8)
-                    {
-                        outputIndex = (uint) inputSelector - 16;
-                    }
-                    else
-                    {
-                        outputIndex = inputSelector - chassisSize;
-                    }
-
-                    dmCard = Chassis.Outputs[outputIndex];
-                }
-                else
-                {
-                    dmCard = Chassis.Inputs[inputSelector];
-                }
-                Chassis.USBEnter.BoolValue = true;
-
-                Debug.LogVerbose(this, "Routing USB for input {0} to {1}", inputSelector, dmCard);
-                ExecuteSwitch(dmCard, Chassis.Outputs[outputSelector], sigType);
-                return;
-            }
 
             var inputCard = inputSelector == 0 ? null : Chassis.Inputs[inputSelector];
             var outputCard = Chassis.Outputs[outputSelector];
 
             ExecuteSwitch(inputCard, outputCard, sigType);
+        }
+
+        /// <summary>
+        /// Executes USB output-side routing (routes a USB source to a switcher output slot).
+        /// In Essentials v3, eRoutingSignalType.UsbOutput was merged into eRoutingSignalType.Usb,
+        /// so this dedicated helper preserves the output-slot routing behaviour that was previously
+        /// in the now-unreachable UsbOutput branch of ExecuteNumericSwitch.
+        /// </summary>
+        private void ExecuteUsbOutputSwitch(ushort inputSelector, ushort outputSelector)
+        {
+            var chassisSize = (uint)Chassis.NumberOfInputs;
+            DMInputOutputBase dmCard;
+
+            Debug.LogVerbose(this, "Executing USB Output switch.\r\n in:{0} output: {1}", inputSelector, outputSelector);
+
+            //routing Output to Output or Input to Output
+            if (inputSelector > chassisSize)
+            {
+                //wanting to route an output to an output. Subtract chassis size and get output, unless it's 8x8
+                //need this to determine USB routing values
+                //8x8 -> 1-8 is inputs 1-8, 17-24 is outputs 1-8
+                //16x16 1-16 is inputs 1-16, 17-32 is outputs 1-16
+                //32x32 1-32 is inputs 1-32, 33-64 is outputs 1-32
+                uint outputIndex;
+
+                if (chassisSize == 8)
+                {
+                    outputIndex = (uint) inputSelector - 16;
+                }
+                else
+                {
+                    outputIndex = inputSelector - chassisSize;
+                }
+
+                dmCard = Chassis.Outputs[outputIndex];
+            }
+            else
+            {
+                dmCard = Chassis.Inputs[inputSelector];
+            }
+            Chassis.USBEnter.BoolValue = true;
+
+            Debug.LogVerbose(this, "Routing USB for input {0} to {1}", inputSelector, dmCard);
+            ExecuteSwitch(dmCard, Chassis.Outputs[outputSelector], eRoutingSignalType.Usb);
         }
 
         #endregion
@@ -1943,7 +1952,7 @@ namespace PepperDash.Essentials.DM
             trilist.SetUShortSigAction(joinMap.OutputAudio.JoinNumber + ioSlotJoin,
                 o => ExecuteNumericSwitch(o, (ushort) ioSlot, eRoutingSignalType.Audio));
             trilist.SetUShortSigAction(joinMap.OutputUsb.JoinNumber + ioSlotJoin,
-                o => ExecuteNumericSwitch(o, (ushort) ioSlot, eRoutingSignalType.Usb));
+                o => ExecuteUsbOutputSwitch(o, (ushort) ioSlot));
             trilist.SetUShortSigAction(joinMap.InputUsb.JoinNumber + ioSlotJoin,
                 o => ExecuteNumericSwitch(o, (ushort) ioSlot, eRoutingSignalType.Usb));
 

--- a/src/Chassis/DmChassisController.cs
+++ b/src/Chassis/DmChassisController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Crestron.SimplSharp;
-using Crestron.SimplSharp.Reflection;
 using Crestron.SimplSharpPro;
 using Crestron.SimplSharpPro.DeviceSupport;
 using Crestron.SimplSharpPro.DM;
@@ -1371,8 +1370,8 @@ namespace PepperDash.Essentials.DM
 
             var output = outputSelector as DMOutput;
 
-            var isUsbInput = (sigType & eRoutingSignalType.UsbInput) == eRoutingSignalType.UsbInput;
-            var isUsbOutput = (sigType & eRoutingSignalType.UsbOutput) == eRoutingSignalType.UsbOutput;
+            var isUsbInput = (sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb;
+            var isUsbOutput = (sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb;
 
             if (output == null && !(isUsbOutput || isUsbInput))
             {
@@ -1423,7 +1422,7 @@ namespace PepperDash.Essentials.DM
                 }
             }
 
-            if ((sigType & eRoutingSignalType.UsbOutput) == eRoutingSignalType.UsbOutput)
+            if ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb)
                 
             {
                Chassis.USBEnter.BoolValue = true;
@@ -1453,7 +1452,7 @@ namespace PepperDash.Essentials.DM
                 }
             }
 
-            if((sigType & eRoutingSignalType.UsbInput) != eRoutingSignalType.UsbInput)
+            if((sigType & eRoutingSignalType.Usb) != eRoutingSignalType.Usb)
             {
                 return;
             }
@@ -1489,7 +1488,7 @@ namespace PepperDash.Essentials.DM
             DMInputOutputBase dmCard;
 
             //Routing Input to Input or Output to Input
-            if ((sigType & eRoutingSignalType.UsbInput) == eRoutingSignalType.UsbInput)
+            if ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb)
             {
                 Debug.LogVerbose(this, "Executing USB Input switch.\r\n in:{0} output: {1}", inputSelector, outputSelector);
                 if (outputSelector > chassisSize)
@@ -1514,7 +1513,7 @@ namespace PepperDash.Essentials.DM
                 ExecuteSwitch(dmCard, Chassis.Inputs[outputSelector], sigType);
                 return;
             }
-            if ((sigType & eRoutingSignalType.UsbOutput) == eRoutingSignalType.UsbOutput)
+            if ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb)
             {
                 Debug.LogVerbose(this, "Executing USB Output switch.\r\n in:{0} output: {1}", inputSelector, outputSelector);
 
@@ -1936,9 +1935,9 @@ namespace PepperDash.Essentials.DM
             trilist.SetUShortSigAction(joinMap.OutputAudio.JoinNumber + ioSlotJoin,
                 o => ExecuteNumericSwitch(o, (ushort) ioSlot, eRoutingSignalType.Audio));
             trilist.SetUShortSigAction(joinMap.OutputUsb.JoinNumber + ioSlotJoin,
-                o => ExecuteNumericSwitch(o, (ushort) ioSlot, eRoutingSignalType.UsbOutput));
+                o => ExecuteNumericSwitch(o, (ushort) ioSlot, eRoutingSignalType.Usb));
             trilist.SetUShortSigAction(joinMap.InputUsb.JoinNumber + ioSlotJoin,
-                o => ExecuteNumericSwitch(o, (ushort) ioSlot, eRoutingSignalType.UsbInput));
+                o => ExecuteNumericSwitch(o, (ushort) ioSlot, eRoutingSignalType.Usb));
 
             //Routing Feedbacks
             VideoOutputFeedbacks[ioSlot].LinkInputSig(trilist.UShortInput[joinMap.OutputVideo.JoinNumber + ioSlotJoin]);
@@ -2210,7 +2209,7 @@ namespace PepperDash.Essentials.DM
     {
         public DmChassisControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "3.0.0";
             TypeNames = new List<string>() { "dmmd8x8", "dmmd8x8rps", "dmmd8x8cpu3", "dmmd8x8cpu3rps", 
                 "dmmd16x16", "dmmd16x16rps", "dmmd16x16cpu3", "dmmd16x16cpu3rps", 
                 "dmmd32x32", "dmmd32x32rps", "dmmd32x32cpu3", "dmmd32x32cpu3rps", 

--- a/src/Chassis/DmChassisController.cs
+++ b/src/Chassis/DmChassisController.cs
@@ -1620,10 +1620,18 @@ namespace PepperDash.Essentials.DM
             Debug.LogDebug("Port is HdmiInputWithCec");
 
             var hdmiInPortWCec = port as HdmiInputWithCEC;
-            
-            
-            SetHdcpStateAction(PropertiesConfig.InputSlotSupportsHdcp2[ioSlot], hdmiInPortWCec, joinMap.HdcpSupportState.JoinNumber + ioSlotJoin, trilist);
-            
+
+            if (!PropertiesConfig.InputSlotSupportsHdcp2.TryGetValue(ioSlot, out var supportsHdcp2))
+            {
+                Debug.LogInformation(this, "Input Slot Supports HDCP2 setting not found for slot {0}. Setting to false. Program may not function as intended.", ioSlot);
+            }
+
+            SetHdcpStateAction(supportsHdcp2, hdmiInPortWCec, joinMap.HdcpSupportState.JoinNumber + ioSlotJoin, trilist);
+
+            if (!InputCardHdcpStateFeedbacks.ContainsKey(ioSlot))
+            {
+                return;
+            }
 
             InputCardHdcpStateFeedbacks[ioSlot].LinkInputSig(
                 trilist.UShortInput[joinMap.HdcpSupportState.JoinNumber + ioSlotJoin]);

--- a/src/Chassis/DmpsAudioOutputController.cs
+++ b/src/Chassis/DmpsAudioOutputController.cs
@@ -346,6 +346,9 @@ namespace PepperDash.Essentials.DM
 
     public class DmpsAudioOutput : IBasicVolumeWithFeedback
     {
+        public string Key { get; private set; }
+        public string Name { get; private set; }
+
         private UShortInputSig Level;
         private bool EnableVolumeSend;
         private ushort VolumeLevelInput;
@@ -364,6 +367,8 @@ namespace PepperDash.Essentials.DM
 
         public DmpsAudioOutput(Dmps3AudioOutputBase output, eDmpsLevelType type)
         {
+            Key = string.Format("dmpsAudioOutput-{0}", type);
+            Name = string.Format("DMPS Audio Output {0}", type);
             VolumeLevelInput = 0;
             EnableVolumeSend = false;
             Type = type;

--- a/src/Chassis/DmpsRoutingController.cs
+++ b/src/Chassis/DmpsRoutingController.cs
@@ -1183,7 +1183,6 @@ namespace PepperDash.Essentials.DM
                 }
 
                 var sigTypeIsUsbOrVideo = ((sigType & eRoutingSignalType.Video) == eRoutingSignalType.Video) ||
-                                          ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb) ||
                                           ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb);
 
                 if (input == null || (input.Number <= Dmps.NumberOfSwitcherInputs && output.Number <= Dmps.NumberOfSwitcherOutputs &&

--- a/src/Chassis/DmpsRoutingController.cs
+++ b/src/Chassis/DmpsRoutingController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -192,7 +192,7 @@ namespace PepperDash.Essentials.DM
             Microphones = new DmpsMicrophoneController(Dmps);
         }
 
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
             // Set input and output names from config
             SetInputNames();
@@ -1183,8 +1183,8 @@ namespace PepperDash.Essentials.DM
                 }
 
                 var sigTypeIsUsbOrVideo = ((sigType & eRoutingSignalType.Video) == eRoutingSignalType.Video) ||
-                                          ((sigType & eRoutingSignalType.UsbInput) == eRoutingSignalType.UsbInput) ||
-                                          ((sigType & eRoutingSignalType.UsbOutput) == eRoutingSignalType.UsbOutput);
+                                          ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb) ||
+                                          ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb);
 
                 if (input == null || (input.Number <= Dmps.NumberOfSwitcherInputs && output.Number <= Dmps.NumberOfSwitcherOutputs &&
                      sigTypeIsUsbOrVideo) ||
@@ -1246,12 +1246,12 @@ namespace PepperDash.Essentials.DM
                         }
                     }
 
-                    if ((sigType & eRoutingSignalType.UsbOutput) == eRoutingSignalType.UsbOutput)
+                    if ((sigType & eRoutingSignalType.Usb) == eRoutingSignalType.Usb)
                     {
                             output.USBRoutedTo = input;
                     }
 
-                    if ((sigType & eRoutingSignalType.UsbInput) != eRoutingSignalType.UsbInput)
+                    if ((sigType & eRoutingSignalType.Usb) != eRoutingSignalType.Usb)
                     {
                         return;
                     }

--- a/src/Chassis/HdMd8xNController.cs
+++ b/src/Chassis/HdMd8xNController.cs
@@ -486,7 +486,7 @@ namespace PepperDash.Essentials.DM.Chassis
 		{
 			public HdMd8xNControllerFactory()
 			{
-                MinimumEssentialsFrameworkVersion = "2.4.5";
+                MinimumEssentialsFrameworkVersion = "3.0.0";
                 TypeNames = new List<string>() { "hdmd8x2", "hdmd8x1" };
 			}
 

--- a/src/Chassis/HdMdNxM4KzEController.cs
+++ b/src/Chassis/HdMdNxM4KzEController.cs
@@ -1,0 +1,444 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Crestron.SimplSharpPro;
+using Crestron.SimplSharpPro.DeviceSupport;
+using Crestron.SimplSharpPro.DM;
+using PepperDash.Core;
+using PepperDash.Essentials.Core;
+using PepperDash.Essentials.Core.Bridges;
+using PepperDash.Essentials.Core.Config;
+using PepperDash.Essentials.DM.Config;
+
+namespace PepperDash.Essentials.DM.Chassis
+{
+	[Description("Wrapper class for HD-MD-NxM-4KZ-E switchers")]
+	public class HdMdNxM4kzEController : CrestronGenericBridgeableBaseDevice, IRoutingNumericWithFeedback, IHasFeedback
+	{
+		private readonly HdMdNxM4kzE _chassis;
+
+		public event EventHandler<RoutingNumericEventArgs> NumericSwitchChange;
+
+		public Dictionary<uint, string> InputNames { get; set; }
+		public Dictionary<uint, string> OutputNames { get; set; }
+
+		public RoutingPortCollection<RoutingInputPort> InputPorts { get; private set; }
+		public RoutingPortCollection<RoutingOutputPort> OutputPorts { get; private set; }
+
+		public FeedbackCollection<BoolFeedback> VideoInputSyncFeedbacks { get; private set; }
+		public FeedbackCollection<IntFeedback> VideoOutputRouteFeedbacks { get; private set; }
+		public FeedbackCollection<StringFeedback> InputNameFeedbacks { get; private set; }
+		public FeedbackCollection<StringFeedback> OutputNameFeedbacks { get; private set; }
+		public FeedbackCollection<StringFeedback> OutputRouteNameFeedbacks { get; private set; }
+		public FeedbackCollection<BoolFeedback> InputHdcpEnableFeedback { get; private set; }
+		public StringFeedback DeviceNameFeedback { get; private set; }
+		public BoolFeedback AutoRouteFeedback { get; private set; }
+
+		#region Constructor
+
+		public HdMdNxM4kzEController(string key, string name, HdMdNxM4kzE chassis,
+			HdMdNxM4kzEPropertiesConfig props)
+			: base(key, name, chassis)
+		{
+			_chassis = chassis;
+			Name = name;
+
+			if (props == null)
+			{
+				Debug.LogDebug(this, "HdMdNxM4kzEController properties are null, failed to build the device");
+				return;
+			}
+
+			InputNames = props.Inputs ?? new Dictionary<uint, string>();
+			OutputNames = props.Outputs ?? new Dictionary<uint, string>();
+
+			DeviceNameFeedback = new StringFeedback(() => Name);
+			AutoRouteFeedback = new BoolFeedback(() => _chassis.AutoRouteOnFeedback.BoolValue);
+
+			VideoInputSyncFeedbacks = new FeedbackCollection<BoolFeedback>();
+			VideoOutputRouteFeedbacks = new FeedbackCollection<IntFeedback>();
+			InputNameFeedbacks = new FeedbackCollection<StringFeedback>();
+			OutputNameFeedbacks = new FeedbackCollection<StringFeedback>();
+			OutputRouteNameFeedbacks = new FeedbackCollection<StringFeedback>();
+			InputHdcpEnableFeedback = new FeedbackCollection<BoolFeedback>();
+
+			InputPorts = new RoutingPortCollection<RoutingInputPort>();
+			OutputPorts = new RoutingPortCollection<RoutingOutputPort>();
+
+			for (uint i = 1; i <= _chassis.NumberOfInputs; i++)
+			{
+				var index = i;
+				if (!InputNames.ContainsKey(index))
+					InputNames[index] = string.Format("Input {0}", index);
+
+				var inputName = InputNames[index];
+				_chassis.HdmiInputs[index].Name.StringValue = inputName;
+
+				InputPorts.Add(new RoutingInputPort(inputName, eRoutingSignalType.AudioVideo,
+					eRoutingPortConnectionType.Hdmi, _chassis.HdmiInputs[index], this)
+				{
+					FeedbackMatchObject = _chassis.HdmiInputs[index]
+				});
+
+				VideoInputSyncFeedbacks.Add(new BoolFeedback(inputName,
+					() => _chassis.HdmiInputs[index].VideoDetectedFeedback.BoolValue));
+
+				InputNameFeedbacks.Add(new StringFeedback(inputName, () => InputNames[index]));
+
+				InputHdcpEnableFeedback.Add(new BoolFeedback(inputName,
+					() => _chassis.HdmiInputs[index].HdmiInputPort.HdcpSupportOnFeedback.BoolValue));
+			}
+
+			for (uint i = 1; i <= _chassis.NumberOfOutputs; i++)
+			{
+				var index = i;
+				if (!OutputNames.ContainsKey(index))
+					OutputNames[index] = string.Format("Output {0}", index);
+
+				var outputName = OutputNames[index];
+
+				OutputPorts.Add(new RoutingOutputPort(outputName, eRoutingSignalType.AudioVideo,
+					eRoutingPortConnectionType.Hdmi, _chassis.HdmiOutputs[index], this)
+				{
+					FeedbackMatchObject = _chassis.HdmiOutputs[index]
+				});
+
+				VideoOutputRouteFeedbacks.Add(new IntFeedback(outputName,
+					() => _chassis.HdmiOutputs[index].VideoOutFeedback == null
+						? 0
+						: (int)_chassis.HdmiOutputs[index].VideoOutFeedback.Number));
+
+				OutputNameFeedbacks.Add(new StringFeedback(outputName, () => OutputNames[index]));
+
+				OutputRouteNameFeedbacks.Add(new StringFeedback(outputName,
+					() => _chassis.HdmiOutputs[index].VideoOutFeedback == null
+						? string.Empty
+						: _chassis.HdmiOutputs[index].VideoOutFeedback.NameFeedback.StringValue));
+			}
+
+			_chassis.DMInputChange += Chassis_DMInputChange;
+			_chassis.DMOutputChange += Chassis_DMOutputChange;
+
+			AddPostActivationAction(AddFeedbackCollections);
+		}
+
+		#endregion
+
+		#region Methods
+
+		private void OnSwitchChange(RoutingNumericEventArgs e)
+		{
+			var newEvent = NumericSwitchChange;
+			if (newEvent != null) newEvent(this, e);
+		}
+
+		public void EnableHdcp(uint port)
+		{
+			if (port <= 0 || port > _chassis.NumberOfInputs) return;
+
+			_chassis.HdmiInputs[port].HdmiInputPort.HdcpSupportOn();
+			InputHdcpEnableFeedback[InputNames[port]].FireUpdate();
+		}
+
+		public void DisableHdcp(uint port)
+		{
+			if (port <= 0 || port > _chassis.NumberOfInputs) return;
+
+			_chassis.HdmiInputs[port].HdmiInputPort.HdcpSupportOff();
+			InputHdcpEnableFeedback[InputNames[port]].FireUpdate();
+		}
+
+		public void EnableAutoRoute()
+		{
+			_chassis.AutoRouteOn();
+			AutoRouteFeedback.FireUpdate();
+		}
+
+		public void DisableAutoRoute()
+		{
+			_chassis.AutoRouteOff();
+			AutoRouteFeedback.FireUpdate();
+		}
+
+		#region PostActivate
+
+		private void AddFeedbackCollections()
+		{
+			AddFeedbackToList(DeviceNameFeedback);
+			AddFeedbackToList(AutoRouteFeedback);
+
+			foreach (var fb in VideoInputSyncFeedbacks)
+				AddFeedbackToList(fb);
+			foreach (var fb in InputHdcpEnableFeedback)
+				AddFeedbackToList(fb);
+			foreach (var fb in VideoOutputRouteFeedbacks)
+				AddFeedbackToList(fb);
+			foreach (var fb in InputNameFeedbacks)
+				AddFeedbackToList(fb);
+			foreach (var fb in OutputNameFeedbacks)
+				AddFeedbackToList(fb);
+			foreach (var fb in OutputRouteNameFeedbacks)
+				AddFeedbackToList(fb);
+		}
+
+		private void AddFeedbackToList(PepperDash.Essentials.Core.Feedback newFb)
+		{
+			if (newFb == null) return;
+
+			if (!Feedbacks.Contains(newFb))
+				Feedbacks.Add(newFb);
+		}
+
+		#endregion
+
+		#region IRouting Members
+
+		public void ExecuteSwitch(object inputSelector, object outputSelector, eRoutingSignalType signalType)
+		{
+			var input = inputSelector as HdMdNxM4kzEHdmiInput;
+			var output = outputSelector as HdMdNxM4kzEHdmiOutput;
+
+			Debug.LogVerbose(this, "ExecuteSwitch: input={0} output={1}", input, output);
+
+			if (output == null)
+			{
+				Debug.LogInformation(this, "Unable to make switch. Output selector is not HdMdNxM4kzEHdmiOutput");
+				return;
+			}
+
+			var current = output.VideoOut;
+			if (current != input)
+				output.VideoOut = input;
+		}
+
+		#endregion
+
+		#region IRoutingNumeric Members
+
+		public void ExecuteNumericSwitch(ushort inputSelector, ushort outputSelector, eRoutingSignalType signalType)
+		{
+			var input = inputSelector == 0 ? null : _chassis.HdmiInputs[inputSelector];
+			var output = _chassis.HdmiOutputs[outputSelector];
+
+			Debug.LogVerbose(this, "ExecuteNumericSwitch: input={0} output={1}", input, output);
+
+			ExecuteSwitch(input, output, signalType);
+		}
+
+		#endregion
+
+		#endregion
+
+		#region Bridge Linking
+
+		public override void LinkToApi(BasicTriList trilist, uint joinStart, string joinMapKey, EiscApiAdvanced bridge)
+		{
+			var joinMap = new HdMdNxM4kEControllerJoinMap(joinStart);
+
+			var joinMapSerialized = JoinMapHelper.GetSerializedJoinMapForDevice(joinMapKey);
+
+			if (!string.IsNullOrEmpty(joinMapSerialized))
+				joinMap = JsonConvert.DeserializeObject<HdMdNxM4kEControllerJoinMap>(joinMapSerialized);
+
+			if (bridge != null)
+			{
+				bridge.AddJoinMap(Key, joinMap);
+			}
+			else
+			{
+				Debug.LogInformation(this, "Please update config to use 'eiscapiadvanced' to get all join map features for this device.");
+			}
+
+			IsOnline.LinkInputSig(trilist.BooleanInput[joinMap.IsOnline.JoinNumber]);
+			DeviceNameFeedback.LinkInputSig(trilist.StringInput[joinMap.Name.JoinNumber]);
+
+			trilist.SetSigTrueAction(joinMap.EnableAutoRoute.JoinNumber, EnableAutoRoute);
+			trilist.SetSigFalseAction(joinMap.EnableAutoRoute.JoinNumber, DisableAutoRoute);
+			AutoRouteFeedback.LinkInputSig(trilist.BooleanInput[joinMap.EnableAutoRoute.JoinNumber]);
+
+			for (uint i = 1; i <= _chassis.NumberOfInputs; i++)
+			{
+				var joinIndex = i - 1;
+				var input = i;
+
+				VideoInputSyncFeedbacks[InputNames[input]].LinkInputSig(
+					trilist.BooleanInput[joinMap.InputSync.JoinNumber + joinIndex]);
+
+				InputHdcpEnableFeedback[InputNames[input]].LinkInputSig(
+					trilist.BooleanInput[joinMap.EnableInputHdcp.JoinNumber + joinIndex]);
+				InputHdcpEnableFeedback[InputNames[input]].LinkComplementInputSig(
+					trilist.BooleanInput[joinMap.DisableInputHdcp.JoinNumber + joinIndex]);
+
+				trilist.SetSigTrueAction(joinMap.EnableInputHdcp.JoinNumber + joinIndex, () => EnableHdcp(input));
+				trilist.SetSigTrueAction(joinMap.DisableInputHdcp.JoinNumber + joinIndex, () => DisableHdcp(input));
+
+				InputNameFeedbacks[InputNames[input]].LinkInputSig(
+					trilist.StringInput[joinMap.InputName.JoinNumber + joinIndex]);
+			}
+
+			for (uint i = 1; i <= _chassis.NumberOfOutputs; i++)
+			{
+				var joinIndex = i - 1;
+				var output = i;
+
+				VideoOutputRouteFeedbacks[OutputNames[output]].LinkInputSig(
+					trilist.UShortInput[joinMap.OutputRoute.JoinNumber + joinIndex]);
+				trilist.SetUShortSigAction(joinMap.OutputRoute.JoinNumber + joinIndex,
+					(a) => ExecuteNumericSwitch(a, (ushort)output, eRoutingSignalType.AudioVideo));
+
+				OutputNameFeedbacks[OutputNames[output]].LinkInputSig(
+					trilist.StringInput[joinMap.OutputName.JoinNumber + joinIndex]);
+				OutputRouteNameFeedbacks[OutputNames[output]].LinkInputSig(
+					trilist.StringInput[joinMap.OutputRoutedName.JoinNumber + joinIndex]);
+			}
+
+			_chassis.OnlineStatusChange += Chassis_OnlineStatusChange;
+
+			trilist.OnlineStatusChange += (d, args) =>
+			{
+				if (!args.DeviceOnLine) return;
+			};
+		}
+
+		#endregion
+
+		#region Events
+
+		private void Chassis_OnlineStatusChange(GenericBase currentDevice, OnlineOfflineEventArgs args)
+		{
+			IsOnline.FireUpdate();
+
+			if (!args.DeviceOnLine) return;
+
+			foreach (var feedback in Feedbacks)
+			{
+				feedback.FireUpdate();
+			}
+
+			AutoRouteFeedback.FireUpdate();
+		}
+
+		private void Chassis_DMOutputChange(Switch device, DMOutputEventArgs args)
+		{
+			if (args.EventId != DMOutputEventIds.VideoOutEventId) return;
+
+			var output = args.Number;
+
+			var inputNumber = _chassis.HdmiOutputs[output].VideoOutFeedback == null
+				? 0
+				: _chassis.HdmiOutputs[output].VideoOutFeedback.Number;
+
+			if (!OutputNames.ContainsKey(output)) return;
+
+			var outputName = OutputNames[output];
+			var feedback = VideoOutputRouteFeedbacks[outputName];
+
+			if (feedback == null) return;
+
+			var inPort = InputPorts.FirstOrDefault(
+				p => p.FeedbackMatchObject == _chassis.HdmiOutputs[output].VideoOutFeedback);
+			var outPort = OutputPorts.FirstOrDefault(
+				p => p.FeedbackMatchObject == _chassis.HdmiOutputs[output]);
+
+			feedback.FireUpdate();
+			OutputRouteNameFeedbacks[outputName]?.FireUpdate();
+
+			OnSwitchChange(new RoutingNumericEventArgs(output, inputNumber, outPort, inPort, eRoutingSignalType.AudioVideo));
+		}
+
+		private void Chassis_DMInputChange(Switch device, DMInputEventArgs args)
+		{
+			switch (args.EventId)
+			{
+				case DMInputEventIds.VideoDetectedEventId:
+				{
+					Debug.LogDebug(this, "Event ID {0}: Updating VideoInputSyncFeedbacks", args.EventId);
+					foreach (var item in VideoInputSyncFeedbacks)
+					{
+						item.FireUpdate();
+					}
+					break;
+				}
+				case DMInputEventIds.InputNameFeedbackEventId:
+				case DMInputEventIds.InputNameEventId:
+				case DMInputEventIds.NameFeedbackEventId:
+				{
+					Debug.LogDebug(this, "Event ID {0}: Updating name feedbacks", args.EventId);
+					Debug.LogDebug(this, "Input {0} Name {1}", args.Number,
+						_chassis.HdmiInputs[args.Number].NameFeedback.StringValue);
+					foreach (var item in InputNameFeedbacks)
+					{
+						item.FireUpdate();
+					}
+					break;
+				}
+				default:
+				{
+					Debug.LogDebug(this, "Unhandled DM Input Event ID {0}", args.EventId);
+					break;
+				}
+			}
+		}
+
+		#endregion
+
+		#region Factory
+
+		public class HdMdNxM4kzEControllerFactory : EssentialsPluginDeviceFactory<HdMdNxM4kzEController>
+		{
+			public HdMdNxM4kzEControllerFactory()
+			{
+				MinimumEssentialsFrameworkVersion = "3.0.0";
+				TypeNames = new List<string>()
+				{
+					"hdmd4x14kze",
+					"hdmd4x24kze",
+					"hdmd4x44kze",
+					"hdmd8x44kze",
+					"hdmd8x84kze"
+				};
+			}
+
+			public override EssentialsDevice BuildDevice(DeviceConfig dc)
+			{
+				Debug.LogDebug("Factory Attempting to create new HD-MD-NxM-4KZ-E Device");
+
+				var props = JsonConvert.DeserializeObject<HdMdNxM4kzEPropertiesConfig>(dc.Properties.ToString());
+
+				if (props == null)
+				{
+					Debug.LogDebug("Factory failed to create HD-MD-NxM-4KZ-E device, properties config was null");
+					return null;
+				}
+
+				var type = dc.Type.ToLower();
+				var control = props.Control;
+				var ipid = control.IpIdInt;
+
+				switch (type)
+				{
+					case "hdmd4x14kze":
+						return new HdMdNxM4kzEController(dc.Key, dc.Name,
+							new HdMd4x14kzE(ipid, Global.ControlSystem), props);
+					case "hdmd4x24kze":
+						return new HdMdNxM4kzEController(dc.Key, dc.Name,
+							new HdMd4x24kzE(ipid, Global.ControlSystem), props);
+					case "hdmd4x44kze":
+						return new HdMdNxM4kzEController(dc.Key, dc.Name,
+							new HdMd4x44kzE(ipid, Global.ControlSystem), props);
+					case "hdmd8x44kze":
+						return new HdMdNxM4kzEController(dc.Key, dc.Name,
+							new HdMd8x44kzE(ipid, Global.ControlSystem), props);
+					case "hdmd8x84kze":
+						return new HdMdNxM4kzEController(dc.Key, dc.Name,
+							new HdMd8x84kzE(ipid, Global.ControlSystem), props);
+					default:
+						return null;
+				}
+			}
+		}
+
+		#endregion
+	}
+}

--- a/src/Chassis/HdMdNxM4kEBridgeableController.cs
+++ b/src/Chassis/HdMdNxM4kEBridgeableController.cs
@@ -467,7 +467,7 @@ namespace PepperDash.Essentials.DM.Chassis
 		{
 			public HdMdNxM4kEControllerFactory()
 			{
-                MinimumEssentialsFrameworkVersion = "2.4.5";
+                MinimumEssentialsFrameworkVersion = "3.0.0";
                 TypeNames = new List<string>() { "hdmd4x14ke-bridgeable", "hdmd4x24ke", "hdmd6x24ke" };
 			}
 

--- a/src/Chassis/HdMdNxM4kEController.cs
+++ b/src/Chassis/HdMdNxM4kEController.cs
@@ -72,7 +72,7 @@ namespace PepperDash.Essentials.DM.Chassis
             }
         }
 
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
             var result = Chassis.Register();
             if (result != Crestron.SimplSharpPro.eDeviceRegistrationUnRegistrationResponse.Success)
@@ -121,7 +121,7 @@ namespace PepperDash.Essentials.DM.Chassis
                 type = type.ToLower();
                 if (type == "hdmd4x14ke")
                 {
-                    Debug.Console(0, @"The 'hdmd4x14ke' device is not an Essentials Bridgeable device.  
+                    Debug.LogInformation(@"The 'hdmd4x14ke' device is not an Essentials Bridgeable device.  
                         If an essentials Bridgeable Device is required, use the 'hdmd4x14ke-bridgeable' type");
   
                     var chassis = new HdMd4x14kE(ipid, address, Global.ControlSystem);

--- a/src/Chassis/HdMdNxM4kEController.cs
+++ b/src/Chassis/HdMdNxM4kEController.cs
@@ -142,6 +142,7 @@ namespace PepperDash.Essentials.DM.Chassis
         {
             public HdMdNxM4kEFactory()
             {
+                MinimumEssentialsFrameworkVersion = "3.0.0";
                 TypeNames = new List<string>() {"hdmd4x14ke"};
             }
 

--- a/src/Chassis/HdPsXxxController.cs
+++ b/src/Chassis/HdPsXxxController.cs
@@ -521,7 +521,7 @@ Selector: {4}
     {
         public HdSp401ControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "3.0.0";
             
             TypeNames = new List<string>() { "hdps401", "hdps402", "hdps621", "hdps622" };
         }

--- a/src/Config/HdMdNxM4kzEPropertiesConfig.cs
+++ b/src/Config/HdMdNxM4kzEPropertiesConfig.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using PepperDash.Core;
+
+namespace PepperDash.Essentials.DM.Config
+{
+    public class HdMdNxM4kzEPropertiesConfig
+    {
+        [JsonProperty("control")]
+        public ControlPropertiesConfig Control { get; set; }
+
+        [JsonProperty("inputs")]
+        public Dictionary<uint, string> Inputs { get; set; }
+
+        [JsonProperty("outputs")]
+        public Dictionary<uint, string> Outputs { get; set; }
+    }
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <Version>2.0.0-local</Version>
+    <Version>3.0.0-local</Version>
     <InformationalVersion>$(Version)</InformationalVersion>
     <Authors>PepperDash Technology</Authors>
     <Company>PepperDash Technology</Company>    

--- a/src/DmLite/HdMdxxxCEController.cs
+++ b/src/DmLite/HdMdxxxCEController.cs
@@ -283,7 +283,7 @@ namespace PepperDash.Essentials.DM
     {
         public HdMdxxxCEControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "3.0.0";
             TypeNames = new List<string>() { "hdmd400ce", "hdmd300ce", "hdmd200ce", "hdmd200c1ge"};
         }
 

--- a/src/Endpoints/DGEs/Dge100Controller.cs
+++ b/src/Endpoints/DGEs/Dge100Controller.cs
@@ -263,7 +263,7 @@ namespace PepperDash.Essentials.DM.Endpoints.DGEs
     {
         public Dge100ControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "3.0.0";
             TypeNames = new List<string>() { "dge100" };
         }
 

--- a/src/Endpoints/DGEs/DmDge200CController.cs
+++ b/src/Endpoints/DGEs/DmDge200CController.cs
@@ -61,7 +61,7 @@ namespace PepperDash.Essentials.DM.Endpoints.DGEs
 	{
 		public DmDge200CControllerFactory()
 		{
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "3.0.0";
             TypeNames = new List<string>() { "dmdge200c" };
 		}
 

--- a/src/Endpoints/Receivers/DmRmcHelper.cs
+++ b/src/Endpoints/Receivers/DmRmcHelper.cs
@@ -608,7 +608,7 @@ namespace PepperDash.Essentials.DM
     {
         public DmRmcControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "3.0.0";
             TypeNames = new List<string>
             { "hdbasetrx", "dmrmc4k100c1g", "dmrmc100c", "dmrmc100s", "dmrmc4k100c", "dmrmc150s",
                 "dmrmc200c", "dmrmc200s", "dmrmc200s2", "dmrmcscalerc", "dmrmcscalers", "dmrmcscalers2", "dmrmc4kscalerc", "dmrmc4kscalercdsp",

--- a/src/Endpoints/Transmitters/DmTx200Controller.cs
+++ b/src/Endpoints/Transmitters/DmTx200Controller.cs
@@ -234,7 +234,7 @@ namespace PepperDash.Essentials.DM
             OnSwitchChange(new RoutingNumericEventArgs(1, AudioSourceNumericFeedback.UShortValue, OutputPorts.First(), localAudioInputPort, eRoutingSignalType.Audio));
         }
 
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
 
             Tx.HdmiInput.InputStreamChange += (o, a) => FowardInputStreamChange(HdmiInput, a.EventId);

--- a/src/Endpoints/Transmitters/DmTx201CController.cs
+++ b/src/Endpoints/Transmitters/DmTx201CController.cs
@@ -243,7 +243,7 @@ namespace PepperDash.Essentials.DM
             }
         }
 
-		public override bool CustomActivate()
+		protected override bool CustomActivate()
 		{		
 			Tx.HdmiInput.InputStreamChange += (o, a) => FowardInputStreamChange(HdmiInput, a.EventId);
 			Tx.HdmiInput.VideoAttributes.AttributeChange += (o, a) => FireVideoAttributeChange(HdmiInput, a.EventId);

--- a/src/Endpoints/Transmitters/DmTx201SController.cs
+++ b/src/Endpoints/Transmitters/DmTx201SController.cs
@@ -245,7 +245,7 @@ namespace PepperDash.Essentials.DM
             }
         }
 
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
             Tx.HdmiInput.InputStreamChange += (o, a) => FowardInputStreamChange(HdmiInput, a.EventId);
             Tx.HdmiInput.VideoAttributes.AttributeChange += (o, a) => FireVideoAttributeChange(HdmiInput, a.EventId);

--- a/src/Endpoints/Transmitters/DmTx401CController.cs
+++ b/src/Endpoints/Transmitters/DmTx401CController.cs
@@ -234,7 +234,7 @@ namespace PepperDash.Essentials.DM
             DmOut.Port = Tx.DmOutput;
 		}
 
-		public override bool CustomActivate()
+		protected override bool CustomActivate()
 		{
 			// Link up all of these damned events to the various RoutingPorts via a helper handler
 			Tx.HdmiInput.InputStreamChange += (o, a) => FowardInputStreamChange(HdmiIn, a.EventId);

--- a/src/Endpoints/Transmitters/DmTx4k202CController.cs
+++ b/src/Endpoints/Transmitters/DmTx4k202CController.cs
@@ -205,7 +205,7 @@ namespace PepperDash.Essentials.DM
 
 
 
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
             // Link up all of these damned events to the various RoutingPorts via a helper handler
             Tx.HdmiInputs[1].InputStreamChange += (o, a) => FowardInputStreamChange(HdmiIn1, a.EventId);

--- a/src/Endpoints/Transmitters/DmTx4k302CController.cs
+++ b/src/Endpoints/Transmitters/DmTx4k302CController.cs
@@ -249,7 +249,7 @@ namespace PepperDash.Essentials.DM
 
 
 
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
             // Link up all of these damned events to the various RoutingPorts via a helper handler
             Tx.HdmiInputs[1].InputStreamChange += (o, a) => FowardInputStreamChange(HdmiIn1, a.EventId);

--- a/src/Endpoints/Transmitters/DmTx4kz202CController.cs
+++ b/src/Endpoints/Transmitters/DmTx4kz202CController.cs
@@ -194,7 +194,7 @@ namespace PepperDash.Essentials.DM
 
 
 
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
             // Link up all of these damned events to the various RoutingPorts via a helper handler
             Tx.HdmiInputs[1].InputStreamChange += (o, a) => FowardInputStreamChange(HdmiIn1, a.EventId);

--- a/src/Endpoints/Transmitters/DmTx4kz302CController.cs
+++ b/src/Endpoints/Transmitters/DmTx4kz302CController.cs
@@ -230,7 +230,7 @@ namespace PepperDash.Essentials.DM
         }
 
 
-        public override bool CustomActivate()
+        protected override bool CustomActivate()
         {
             // Link up all of these damned events to the various RoutingPorts via a helper handler
             Tx.HdmiInputs[1].InputStreamChange += (o, a) => FowardInputStreamChange(HdmiIn1, a.EventId);

--- a/src/Endpoints/Transmitters/DmTxHelpers.cs
+++ b/src/Endpoints/Transmitters/DmTxHelpers.cs
@@ -490,7 +490,7 @@ namespace PepperDash.Essentials.DM
     {
         public DmTxControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "3.0.0";
             TypeNames = new List<string>
             {
                 "dmtx200c",

--- a/src/PepperDash.Essentials.DM.csproj
+++ b/src/PepperDash.Essentials.DM.csproj
@@ -3,7 +3,7 @@
 	    <ProjectType>ProgramLibrary</ProjectType>
     </PropertyGroup>
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <RootNamespace>PepperDash.Essentials.DM</RootNamespace>
     <Deterministic>false</Deterministic>
     <AssemblyTitle>PepperDash.Essentials.DM</AssemblyTitle>
@@ -12,13 +12,13 @@
     <OutputPath>4Series\bin\$(Configuration)\</OutputPath>    
     <PackageId>PepperDash.Essentials.Plugin.4Series.DM</PackageId>
     <PackageProjectUrl>https://github.com/PepperDash/PepperDash.Essentials.DM.git</PackageProjectUrl>
-    <PackageTags>crestron 4series essentials plugin</PackageTags>
+    <PackageTags>crestron net8 essentials plugin dm</PackageTags>
     <Product>PepperDash Essentials DM</Product>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Title>PepperDash Essentials DM 4Series Plugin</Title>    
+    <Title>PepperDash Essentials DM Plugin</Title>    
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/PepperDash/PepperDash.Essentials.DM</RepositoryUrl>
-    <PackageTags>crestron;4series;</PackageTags>
+    <PackageTags>crestron;net8;essentials;dm;</PackageTags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -27,15 +27,11 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="PepperDashEssentials" Version="2.7.0">
+    <PackageReference Include="PepperDashEssentials" Version="3.0.0-dev-v3-testing.13">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
+
   <ItemGroup>
     <None Include="Chassis\Config\Schema\DmChassisControllerPropertiesConfigSchema.json" />
     <None Include="LICENSE.md" />

--- a/src/PepperDash.Essentials.DM.csproj
+++ b/src/PepperDash.Essentials.DM.csproj
@@ -27,7 +27,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="PepperDashEssentials" Version="3.0.0-dev-v3-testing.13">
+    <PackageReference Include="PepperDashEssentials" Version="3.0.0-dev-v3-testing.50">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/Routing/DmMatrixInput.cs
+++ b/src/Routing/DmMatrixInput.cs
@@ -44,7 +44,7 @@ namespace PepperDash.Essentials.DM.Routing
 
         public int SlotNumber => (int)_device.SwitcherInputOutput.Number;
 
-        public eRoutingSignalType SupportedSignalTypes => eRoutingSignalType.AudioVideo | eRoutingSignalType.SecondaryAudio;
+        public eRoutingSignalType SupportedSignalTypes => eRoutingSignalType.AudioVideo;
 
         public string Name { get; private set; }
 

--- a/src/Routing/DmMatrixOutput.cs
+++ b/src/Routing/DmMatrixOutput.cs
@@ -70,8 +70,7 @@ namespace PepperDash.Essentials.DM.Routing
         {
             {eRoutingSignalType.Audio, default },
             {eRoutingSignalType.Video, default },
-            {eRoutingSignalType.UsbInput, default },
-            {eRoutingSignalType.UsbOutput, default },
+            {eRoutingSignalType.Usb, default },
         };
 
         private void SetInputRoute(eRoutingSignalType type, IRoutingInputSlot input)

--- a/src/VideoWindowing/HdWp4k401cController.cs
+++ b/src/VideoWindowing/HdWp4k401cController.cs
@@ -412,7 +412,7 @@ namespace PepperDash.Essentials.DM.VideoWindowing
         {
             public HdWp4k401cControllerFactory()
             {
-                MinimumEssentialsFrameworkVersion = "2.4.5";
+                MinimumEssentialsFrameworkVersion = "3.0.0";
                 TypeNames = new List<string>() { "hdWp4k401c" };
             }
 

--- a/tests/AssemblyFixture.cs
+++ b/tests/AssemblyFixture.cs
@@ -42,6 +42,12 @@ public static class AssemblyFixture
         var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
         var dllByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+        // Fail clearly if the plugin hasn't been built yet, rather than letting
+        // Directory.GetFiles throw a less actionable DirectoryNotFoundException below.
+        if (!File.Exists(PluginDllPath))
+            throw new FileNotFoundException(
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.");
+
         // Priority 1: Plugin output dir (correct versions win)
         foreach (var dll in Directory.GetFiles(PluginOutputDir, "*.dll"))
             dllByName[Path.GetFileName(dll)] = dll;
@@ -63,9 +69,12 @@ public static class AssemblyFixture
 
     private static IEnumerable<string> ResolveDepsJsonAssemblies(string depsJsonPath)
     {
-        var nugetDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".nuget", "packages");
+        // Honor NUGET_PACKAGES (common in CI / enterprise setups); fall back to the default.
+        var nugetDir = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (string.IsNullOrEmpty(nugetDir))
+            nugetDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".nuget", "packages");
 
         using var stream = File.OpenRead(depsJsonPath);
         using var doc = JsonDocument.Parse(stream);

--- a/tests/AssemblyFixture.cs
+++ b/tests/AssemblyFixture.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace PepperDash.Essentials.DM.Tests;
+
+/// <summary>
+/// Shared assembly loading infrastructure for all test classes.
+/// Uses MetadataLoadContext for safe, reflection-only inspection of the
+/// plugin assembly — no Crestron SDK or hardware dependencies required.
+/// </summary>
+public static class AssemblyFixture
+{
+    private static readonly Lazy<MetadataLoadContext> LazyContext = new(CreateContext);
+    private static readonly Lazy<Assembly> LazyAssembly = new(LoadPluginAssembly);
+
+    /// <summary>
+    /// Path to the built DM plugin DLL. Assumes the DM project has been built in Debug.
+    /// </summary>
+    private static string PluginDllPath =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, // tests bin dir
+            "..", "..", "..", "..",   // up to repo root
+            "src", "4Series", "bin", "Debug", "net8",
+            "PepperDash.Essentials.DM.dll"));
+
+    private static string PluginOutputDir => Path.GetDirectoryName(PluginDllPath)!;
+
+    public static MetadataLoadContext Context => LazyContext.Value;
+    public static Assembly PluginAssembly => LazyAssembly.Value;
+
+    private static MetadataLoadContext CreateContext()
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+
+        // Collect DLLs from: .NET runtime, plugin output, and NuGet global packages cache
+        var dllPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var dll in Directory.GetFiles(runtimeDir, "*.dll"))
+            dllPaths.Add(dll);
+
+        foreach (var dll in Directory.GetFiles(PluginOutputDir, "*.dll"))
+            dllPaths.Add(dll);
+
+        // Search NuGet global packages cache for referenced assemblies
+        var nugetDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".nuget", "packages");
+
+        if (Directory.Exists(nugetDir))
+        {
+            foreach (var dll in Directory.GetFiles(nugetDir, "*.dll", SearchOption.AllDirectories))
+                dllPaths.Add(dll);
+        }
+
+        var resolver = new PathAssemblyResolver(dllPaths);
+        return new MetadataLoadContext(resolver);
+    }
+
+    private static Assembly LoadPluginAssembly()
+    {
+        if (!File.Exists(PluginDllPath))
+            throw new FileNotFoundException(
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the DM project first (dotnet build src).");
+
+        return Context.LoadFromAssemblyPath(PluginDllPath);
+    }
+
+    /// <summary>
+    /// Find all types whose base class is a generic type with a name starting with the given prefix.
+    /// This works across assembly boundaries in MetadataLoadContext.
+    /// </summary>
+    public static List<Type> FindFactoryTypes(string baseTypePrefix = "EssentialsPluginDeviceFactory")
+    {
+        return PluginAssembly.GetTypes()
+            .Where(t => !t.IsAbstract
+                && t.BaseType is { IsGenericType: true }
+                && t.BaseType.GetGenericTypeDefinition().Name.StartsWith(baseTypePrefix))
+            .ToList();
+    }
+}

--- a/tests/AssemblyFixture.cs
+++ b/tests/AssemblyFixture.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
-using FluentAssertions;
-using Xunit;
+using System.Text.Json;
 
 namespace PepperDash.Essentials.DM.Tests;
 
@@ -14,14 +13,23 @@ public static class AssemblyFixture
     private static readonly Lazy<MetadataLoadContext> LazyContext = new(CreateContext);
     private static readonly Lazy<Assembly> LazyAssembly = new(LoadPluginAssembly);
 
-    /// <summary>
-    /// Path to the built DM plugin DLL. Assumes the DM project has been built in Debug.
-    /// </summary>
+    private static string Configuration
+    {
+        get
+        {
+            // Derive from test output path: tests/bin/{Configuration}/net8.0/
+            var baseDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+            var parts = baseDir.Split(Path.DirectorySeparatorChar);
+            return parts[^2]; // net8.0 is last, Configuration is second-to-last
+        }
+    }
+
+    // This plugin outputs to src/4Series/bin/{Config}/net8/ (OutputPath = 4Series\bin\$(Configuration)\).
     private static string PluginDllPath =>
         Path.GetFullPath(Path.Combine(
-            AppContext.BaseDirectory, // tests bin dir
-            "..", "..", "..", "..",   // up to repo root
-            "src", "4Series", "bin", "Debug", "net8",
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..",
+            "src", "4Series", "bin", Configuration, "net8",
             "PepperDash.Essentials.DM.dll"));
 
     private static string PluginOutputDir => Path.GetDirectoryName(PluginDllPath)!;
@@ -32,29 +40,57 @@ public static class AssemblyFixture
     private static MetadataLoadContext CreateContext()
     {
         var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var dllByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        // Collect DLLs from: .NET runtime, plugin output, and NuGet global packages cache
-        var dllPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var dll in Directory.GetFiles(runtimeDir, "*.dll"))
-            dllPaths.Add(dll);
-
+        // Priority 1: Plugin output dir (correct versions win)
         foreach (var dll in Directory.GetFiles(PluginOutputDir, "*.dll"))
-            dllPaths.Add(dll);
+            dllByName[Path.GetFileName(dll)] = dll;
 
-        // Search NuGet global packages cache for referenced assemblies
+        // Priority 2: .NET runtime
+        foreach (var dll in Directory.GetFiles(runtimeDir, "*.dll"))
+            dllByName.TryAdd(Path.GetFileName(dll), dll);
+
+        // Priority 3: Deterministic deps.json resolution for transitive packages
+        var depsJsonPath = Path.ChangeExtension(PluginDllPath, ".deps.json");
+        if (File.Exists(depsJsonPath))
+        {
+            foreach (var path in ResolveDepsJsonAssemblies(depsJsonPath))
+                dllByName.TryAdd(Path.GetFileName(path), path);
+        }
+
+        return new MetadataLoadContext(new PathAssemblyResolver(dllByName.Values));
+    }
+
+    private static IEnumerable<string> ResolveDepsJsonAssemblies(string depsJsonPath)
+    {
         var nugetDir = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             ".nuget", "packages");
 
-        if (Directory.Exists(nugetDir))
-        {
-            foreach (var dll in Directory.GetFiles(nugetDir, "*.dll", SearchOption.AllDirectories))
-                dllPaths.Add(dll);
-        }
+        using var stream = File.OpenRead(depsJsonPath);
+        using var doc = JsonDocument.Parse(stream);
 
-        var resolver = new PathAssemblyResolver(dllPaths);
-        return new MetadataLoadContext(resolver);
+        if (!doc.RootElement.TryGetProperty("libraries", out var libraries))
+            yield break;
+
+        foreach (var lib in libraries.EnumerateObject())
+        {
+            if (!lib.Value.TryGetProperty("type", out var typeProp) || typeProp.GetString() != "package")
+                continue;
+            if (!lib.Value.TryGetProperty("path", out var pathProp))
+                continue;
+
+            var packagePath = Path.Combine(nugetDir, pathProp.GetString()!);
+            if (!Directory.Exists(packagePath)) continue;
+
+            var libDir = Path.Combine(packagePath, "lib", "net8.0");
+            if (!Directory.Exists(libDir))
+                libDir = Path.Combine(packagePath, "lib", "netstandard2.0");
+            if (!Directory.Exists(libDir)) continue;
+
+            foreach (var dll in Directory.GetFiles(libDir, "*.dll"))
+                yield return dll;
+        }
     }
 
     private static Assembly LoadPluginAssembly()

--- a/tests/ConfigDeserializationTests.cs
+++ b/tests/ConfigDeserializationTests.cs
@@ -56,6 +56,19 @@ public class ConfigDeserializationTests
     }
 
     // -------------------------------------------------------------------
+    // HdMdNxM4kzEPropertiesConfig
+    // -------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("HdMdNxM4kzEPropertiesConfig", "control")]
+    [InlineData("HdMdNxM4kzEPropertiesConfig", "inputs")]
+    [InlineData("HdMdNxM4kzEPropertiesConfig", "outputs")]
+    public void HdMdNxM4kzEConfig_Has_JsonProperty(string className, string jsonPropertyName)
+    {
+        AssertTypeHasJsonProperty(className, jsonPropertyName);
+    }
+
+    // -------------------------------------------------------------------
     // DmCardAudioPropertiesConfig
     // -------------------------------------------------------------------
 
@@ -115,6 +128,7 @@ public class ConfigDeserializationTests
     [InlineData("DgePropertiesConfig")]
     [InlineData("HdPsXxxPropertiesConfig")]
     [InlineData("DmpsRoutingPropertiesConfig")]
+    [InlineData("HdMdNxM4kzEPropertiesConfig")]
     public void Config_Has_Parameterless_Constructor(string className)
     {
         var type = FindType(className);

--- a/tests/ConfigDeserializationTests.cs
+++ b/tests/ConfigDeserializationTests.cs
@@ -1,0 +1,161 @@
+using System.Reflection;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace PepperDash.Essentials.DM.Tests;
+
+/// <summary>
+/// Validates that config/properties classes have the expected JSON property structure.
+/// Uses MetadataLoadContext for type inspection — no Crestron SDK needed.
+/// </summary>
+public class ConfigDeserializationTests
+{
+    // -------------------------------------------------------------------
+    // DMChassisPropertiesConfig
+    // -------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("DMChassisPropertiesConfig", "control")]
+    [InlineData("DMChassisPropertiesConfig", "volumeControls")]
+    [InlineData("DMChassisPropertiesConfig", "inputSlots")]
+    [InlineData("DMChassisPropertiesConfig", "outputSlots")]
+    [InlineData("DMChassisPropertiesConfig", "inputNames")]
+    [InlineData("DMChassisPropertiesConfig", "outputNames")]
+    [InlineData("DMChassisPropertiesConfig", "noRouteText")]
+    [InlineData("DMChassisPropertiesConfig", "inputSlotSupportsHdcp2")]
+    public void DMChassisConfig_Has_JsonProperty(string className, string jsonPropertyName)
+    {
+        AssertTypeHasJsonProperty(className, jsonPropertyName);
+    }
+
+    // -------------------------------------------------------------------
+    // HdMdNxM4kEPropertiesConfig
+    // -------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("HdMdNxM4kEPropertiesConfig", "control")]
+    [InlineData("HdMdNxM4kEPropertiesConfig", "inputs")]
+    public void HdMdNxM4kEConfig_Has_JsonProperty(string className, string jsonPropertyName)
+    {
+        AssertTypeHasJsonProperty(className, jsonPropertyName);
+    }
+
+    // -------------------------------------------------------------------
+    // HdMdNxM4kEBridgeablePropertiesConfig
+    // -------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("HdMdNxM4kEBridgeablePropertiesConfig", "control")]
+    [InlineData("HdMdNxM4kEBridgeablePropertiesConfig", "inputs")]
+    [InlineData("HdMdNxM4kEBridgeablePropertiesConfig", "outputs")]
+    public void HdMdNxM4kEBridgeableConfig_Has_JsonProperty(string className, string jsonPropertyName)
+    {
+        AssertTypeHasJsonProperty(className, jsonPropertyName);
+    }
+
+    // -------------------------------------------------------------------
+    // DmCardAudioPropertiesConfig
+    // -------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("DmCardAudioPropertiesConfig", "outLevel")]
+    [InlineData("DmCardAudioPropertiesConfig", "isVolumeControlPoint")]
+    public void DmCardAudioConfig_Has_JsonProperty(string className, string jsonPropertyName)
+    {
+        AssertTypeHasJsonProperty(className, jsonPropertyName);
+    }
+
+    // -------------------------------------------------------------------
+    // AirMediaPropertiesConfig
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void AirMediaPropertiesConfig_Exists()
+    {
+        var type = FindType("AirMediaPropertiesConfig");
+        type.Should().NotBeNull();
+    }
+
+    // -------------------------------------------------------------------
+    // DmTxPropertiesConfig
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void DmTxPropertiesConfig_Exists()
+    {
+        var type = FindType("DmTxPropertiesConfig");
+        type.Should().NotBeNull();
+    }
+
+    // -------------------------------------------------------------------
+    // DmRmcPropertiesConfig
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void DmRmcPropertiesConfig_Exists()
+    {
+        var type = FindType("DmRmcPropertiesConfig");
+        type.Should().NotBeNull();
+    }
+
+    // -------------------------------------------------------------------
+    // Config classes should have parameterless constructors
+    // -------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("DMChassisPropertiesConfig")]
+    [InlineData("DmCardAudioPropertiesConfig")]
+    [InlineData("HdMdNxM4kEPropertiesConfig")]
+    [InlineData("HdMdNxM4kEBridgeablePropertiesConfig")]
+    [InlineData("AirMediaPropertiesConfig")]
+    [InlineData("DmTxPropertiesConfig")]
+    [InlineData("DmRmcPropertiesConfig")]
+    [InlineData("DgePropertiesConfig")]
+    [InlineData("HdPsXxxPropertiesConfig")]
+    [InlineData("DmpsRoutingPropertiesConfig")]
+    public void Config_Has_Parameterless_Constructor(string className)
+    {
+        var type = FindType(className);
+        type.Should().NotBeNull($"config class '{className}' should exist");
+        type!.GetConstructor(Type.EmptyTypes).Should()
+            .NotBeNull($"config class '{className}' must have a parameterless constructor for deserialization");
+    }
+
+    // -------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------
+
+    private static void AssertTypeHasJsonProperty(string className, string jsonPropertyName)
+    {
+        var type = FindType(className);
+        type.Should().NotBeNull($"config class '{className}' should exist");
+
+        // Check source file for [JsonProperty("name")] attribute
+        var srcDir = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "src"));
+        var csFiles = Directory.GetFiles(srcDir, "*.cs", SearchOption.AllDirectories);
+
+        string? sourceContent = null;
+        foreach (var file in csFiles)
+        {
+            var content = File.ReadAllText(file);
+            if (content.Contains($"class {className}"))
+            {
+                sourceContent = content;
+                break;
+            }
+        }
+
+        sourceContent.Should().NotBeNull($"source file for '{className}' should exist");
+        sourceContent.Should().Contain($"\"{jsonPropertyName}\"",
+            $"'{className}' should have a property with [JsonProperty(\"{jsonPropertyName}\")]");
+    }
+
+    private static Type? FindType(string className)
+    {
+        return AssemblyFixture.PluginAssembly.GetTypes()
+            .FirstOrDefault(t => t.Name == className);
+    }
+}

--- a/tests/FactoryDiscoveryTests.cs
+++ b/tests/FactoryDiscoveryTests.cs
@@ -46,9 +46,9 @@ public class FactoryDiscoveryTests
     {
         var factoryTypes = AssemblyFixture.FindFactoryTypes();
 
-        // 12 factories: DmChassis, HdMdNxM4kE, HdMdNxM4kEBridgeable, HdMd8xN,
+        // 13 factories: DmChassis, HdMdNxM4kE, HdMdNxM4kEBridgeable, HdMdNxM4kzE, HdMd8xN,
         // HdSp401, HdMdxxxCE, AirMedia, DmTx, DmRmc, DmDge200C, Dge100, HdWp4k401c
-        factoryTypes.Should().HaveCount(12);
+        factoryTypes.Should().HaveCount(13);
     }
 
     [Theory]
@@ -64,6 +64,7 @@ public class FactoryDiscoveryTests
     [InlineData("DmDge200CControllerFactory")]
     [InlineData("Dge100ControllerFactory")]
     [InlineData("HdWp4k401cControllerFactory")]
+    [InlineData("HdMdNxM4kzEControllerFactory")]
     public void Factory_Exists_ByName(string factoryClassName)
     {
         var factoryTypes = AssemblyFixture.FindFactoryTypes();

--- a/tests/FactoryDiscoveryTests.cs
+++ b/tests/FactoryDiscoveryTests.cs
@@ -1,0 +1,89 @@
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace PepperDash.Essentials.DM.Tests;
+
+/// <summary>
+/// Tests that validate plugin assembly loading and factory discovery —
+/// mirrors what Essentials does at startup when loading a CPLZ plugin.
+/// Uses MetadataLoadContext for reflection-only inspection (no Crestron SDK needed).
+/// </summary>
+public class FactoryDiscoveryTests
+{
+    private Assembly PluginAssembly => AssemblyFixture.PluginAssembly;
+
+    // -------------------------------------------------------------------
+    // Assembly Loading
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void Assembly_Loads_Successfully()
+    {
+        PluginAssembly.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Assembly_Name_Matches_Expected()
+    {
+        PluginAssembly.GetName().Name.Should().Be("PepperDash.Essentials.DM");
+    }
+
+    // -------------------------------------------------------------------
+    // Factory Discovery
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void All_Factory_Types_Are_Discoverable()
+    {
+        var factoryTypes = AssemblyFixture.FindFactoryTypes();
+
+        factoryTypes.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Factory_Count_Matches_Expected()
+    {
+        var factoryTypes = AssemblyFixture.FindFactoryTypes();
+
+        // 12 factories: DmChassis, HdMdNxM4kE, HdMdNxM4kEBridgeable, HdMd8xN,
+        // HdSp401, HdMdxxxCE, AirMedia, DmTx, DmRmc, DmDge200C, Dge100, HdWp4k401c
+        factoryTypes.Should().HaveCount(12);
+    }
+
+    [Theory]
+    [InlineData("DmChassisControllerFactory")]
+    [InlineData("HdMdNxM4kEFactory")]
+    [InlineData("HdMdNxM4kEControllerFactory")]
+    [InlineData("HdMd8xNControllerFactory")]
+    [InlineData("HdSp401ControllerFactory")]
+    [InlineData("HdMdxxxCEControllerFactory")]
+    [InlineData("AirMediaControllerFactory")]
+    [InlineData("DmTxControllerFactory")]
+    [InlineData("DmRmcControllerFactory")]
+    [InlineData("DmDge200CControllerFactory")]
+    [InlineData("Dge100ControllerFactory")]
+    [InlineData("HdWp4k401cControllerFactory")]
+    public void Factory_Exists_ByName(string factoryClassName)
+    {
+        var factoryTypes = AssemblyFixture.FindFactoryTypes();
+        factoryTypes.Should().Contain(t => t.Name == factoryClassName,
+            $"factory '{factoryClassName}' should be discoverable");
+    }
+
+    // -------------------------------------------------------------------
+    // Factory Constructor Availability
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void All_Factories_Have_Parameterless_Constructor()
+    {
+        var factoryTypes = AssemblyFixture.FindFactoryTypes();
+
+        foreach (var factoryType in factoryTypes)
+        {
+            factoryType.GetConstructor(Type.EmptyTypes).Should()
+                .NotBeNull($"factory '{factoryType.Name}' must have a parameterless constructor for plugin discovery");
+        }
+    }
+}

--- a/tests/FactoryMetadataTests.cs
+++ b/tests/FactoryMetadataTests.cs
@@ -1,0 +1,209 @@
+using System.Reflection;
+using FluentAssertions;
+using Xunit;
+
+namespace PepperDash.Essentials.DM.Tests;
+
+/// <summary>
+/// Validates factory metadata (TypeNames, MinimumEssentialsFrameworkVersion) via reflection.
+/// Incorrect metadata is the most common cause of silent plugin load failures.
+/// Uses MetadataLoadContext — no Crestron SDK or hardware required.
+/// </summary>
+public class FactoryMetadataTests
+{
+    // -------------------------------------------------------------------
+    // MinimumEssentialsFrameworkVersion (via source scanning)
+    // -------------------------------------------------------------------
+    // MetadataLoadContext cannot execute constructors, so we verify metadata
+    // by scanning source files for the expected patterns.
+
+    /// <summary>
+    /// Scans all .cs files in the src directory for factory constructors and verifies
+    /// that MinimumEssentialsFrameworkVersion is set to "3.0.0" in each one.
+    /// </summary>
+    [Fact]
+    public void All_Factory_Sources_Set_MinimumEssentialsFrameworkVersion_To_3()
+    {
+        var srcDir = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "src"));
+        var csFiles = Directory.GetFiles(srcDir, "*.cs", SearchOption.AllDirectories);
+
+        var factoryTypes = AssemblyFixture.FindFactoryTypes();
+        var issues = new List<string>();
+
+        foreach (var factoryType in factoryTypes)
+        {
+            // Find the source file containing this factory class
+            var factoryName = factoryType.Name;
+            var found = false;
+
+            foreach (var file in csFiles)
+            {
+                var content = File.ReadAllText(file);
+                if (!content.Contains($"class {factoryName}")) continue;
+
+                found = true;
+
+                if (!content.Contains("MinimumEssentialsFrameworkVersion"))
+                {
+                    issues.Add($"{factoryName}: MinimumEssentialsFrameworkVersion not set");
+                }
+                else if (!content.Contains("\"3.0.0\""))
+                {
+                    issues.Add($"{factoryName}: MinimumEssentialsFrameworkVersion is not \"3.0.0\"");
+                }
+                break;
+            }
+
+            if (!found)
+            {
+                issues.Add($"{factoryName}: source file not found");
+            }
+        }
+
+        issues.Should().BeEmpty(
+            $"all factories must set MinimumEssentialsFrameworkVersion to \"3.0.0\":\n{string.Join("\n", issues)}");
+    }
+
+    // -------------------------------------------------------------------
+    // TypeNames (via source scanning)
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void All_Factory_Sources_Set_TypeNames()
+    {
+        var srcDir = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "src"));
+        var csFiles = Directory.GetFiles(srcDir, "*.cs", SearchOption.AllDirectories);
+
+        var factoryTypes = AssemblyFixture.FindFactoryTypes();
+        var issues = new List<string>();
+
+        foreach (var factoryType in factoryTypes)
+        {
+            var factoryName = factoryType.Name;
+
+            foreach (var file in csFiles)
+            {
+                var content = File.ReadAllText(file);
+                if (!content.Contains($"class {factoryName}")) continue;
+
+                if (!content.Contains("TypeNames"))
+                {
+                    issues.Add($"{factoryName}: TypeNames not set");
+                }
+                break;
+            }
+        }
+
+        issues.Should().BeEmpty(
+            $"all factories must set TypeNames:\n{string.Join("\n", issues)}");
+    }
+
+    // -------------------------------------------------------------------
+    // TypeNames — expected device types are registered
+    // -------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("DmChassisControllerFactory", "dmmd8x8")]
+    [InlineData("DmChassisControllerFactory", "dmmd16x16")]
+    [InlineData("DmChassisControllerFactory", "dmmd32x32")]
+    [InlineData("DmChassisControllerFactory", "dmmd64x64")]
+    [InlineData("DmChassisControllerFactory", "dmmd128x128")]
+    [InlineData("DmTxControllerFactory", "dmtx200c")]
+    [InlineData("DmTxControllerFactory", "dmtx201c")]
+    [InlineData("DmTxControllerFactory", "dmtx4k202c")]
+    [InlineData("DmTxControllerFactory", "dmtx4kz302c")]
+    [InlineData("DmTxControllerFactory", "dmtx401c")]
+    [InlineData("DmRmcControllerFactory", "dmrmc100c")]
+    [InlineData("DmRmcControllerFactory", "dmrmc4k100c")]
+    [InlineData("DmRmcControllerFactory", "dmrmc4kscalerc")]
+    [InlineData("AirMediaControllerFactory", "am200")]
+    [InlineData("AirMediaControllerFactory", "am300")]
+    [InlineData("AirMediaControllerFactory", "am3200")]
+    [InlineData("HdMdNxM4kEFactory", "hdmd4x14ke")]
+    [InlineData("HdMdNxM4kEControllerFactory", "hdmd4x14ke-bridgeable")]
+    [InlineData("HdMdNxM4kEControllerFactory", "hdmd4x24ke")]
+    [InlineData("HdMd8xNControllerFactory", "hdmd8x2")]
+    [InlineData("HdMd8xNControllerFactory", "hdmd8x1")]
+    [InlineData("HdSp401ControllerFactory", "hdps401")]
+    [InlineData("HdMdxxxCEControllerFactory", "hdmd400ce")]
+    [InlineData("Dge100ControllerFactory", "dge100")]
+    [InlineData("DmDge200CControllerFactory", "dmdge200c")]
+    [InlineData("HdWp4k401cControllerFactory", "hdWp4k401c")]
+    public void Factory_Source_Contains_TypeName(string factoryClassName, string expectedTypeName)
+    {
+        var srcDir = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "src"));
+        var csFiles = Directory.GetFiles(srcDir, "*.cs", SearchOption.AllDirectories);
+
+        string? factorySource = null;
+
+        foreach (var file in csFiles)
+        {
+            var content = File.ReadAllText(file);
+            if (content.Contains($"class {factoryClassName}"))
+            {
+                factorySource = content;
+                break;
+            }
+        }
+
+        factorySource.Should().NotBeNull($"factory '{factoryClassName}' source should exist");
+        factorySource.Should().Contain($"\"{expectedTypeName}\"",
+            $"factory '{factoryClassName}' should register type name '{expectedTypeName}'");
+    }
+
+    // -------------------------------------------------------------------
+    // No duplicate TypeNames across factory source files
+    // -------------------------------------------------------------------
+
+    [Fact]
+    public void No_Duplicate_TypeNames_Across_Factory_Sources()
+    {
+        var srcDir = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "src"));
+        var csFiles = Directory.GetFiles(srcDir, "*.cs", SearchOption.AllDirectories);
+
+        var factoryTypes = AssemblyFixture.FindFactoryTypes();
+        var allTypeNames = new List<(string Factory, string TypeName)>();
+
+        foreach (var factoryType in factoryTypes)
+        {
+            var factoryName = factoryType.Name;
+
+            foreach (var file in csFiles)
+            {
+                var content = File.ReadAllText(file);
+                if (!content.Contains($"class {factoryName}")) continue;
+
+                // Extract quoted strings from TypeNames list
+                var typeNamesIdx = content.IndexOf("TypeNames", StringComparison.Ordinal);
+                if (typeNamesIdx < 0) break;
+
+                var afterTypeNames = content[typeNamesIdx..];
+                var closingBrace = afterTypeNames.IndexOf("};", StringComparison.Ordinal);
+                if (closingBrace < 0) closingBrace = afterTypeNames.IndexOf("}", StringComparison.Ordinal);
+                if (closingBrace < 0) break;
+
+                var typeNamesBlock = afterTypeNames[..closingBrace];
+                var matches = System.Text.RegularExpressions.Regex.Matches(typeNamesBlock, "\"([^\"]+)\"");
+
+                foreach (System.Text.RegularExpressions.Match match in matches)
+                {
+                    allTypeNames.Add((factoryName, match.Groups[1].Value));
+                }
+                break;
+            }
+        }
+
+        var duplicates = allTypeNames
+            .GroupBy(x => x.TypeName, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .Select(g => $"{g.Key} (in {string.Join(", ", g.Select(x => x.Factory))})")
+            .ToList();
+
+        duplicates.Should().BeEmpty(
+            $"duplicate TypeNames found across factories: {string.Join("; ", duplicates)}");
+    }
+}

--- a/tests/FactoryMetadataTests.cs
+++ b/tests/FactoryMetadataTests.cs
@@ -131,6 +131,11 @@ public class FactoryMetadataTests
     [InlineData("Dge100ControllerFactory", "dge100")]
     [InlineData("DmDge200CControllerFactory", "dmdge200c")]
     [InlineData("HdWp4k401cControllerFactory", "hdWp4k401c")]
+    [InlineData("HdMdNxM4kzEControllerFactory", "hdmd4x14kze")]
+    [InlineData("HdMdNxM4kzEControllerFactory", "hdmd4x24kze")]
+    [InlineData("HdMdNxM4kzEControllerFactory", "hdmd4x44kze")]
+    [InlineData("HdMdNxM4kzEControllerFactory", "hdmd8x44kze")]
+    [InlineData("HdMdNxM4kzEControllerFactory", "hdmd8x84kze")]
     public void Factory_Source_Contains_TypeName(string factoryClassName, string expectedTypeName)
     {
         var srcDir = Path.GetFullPath(Path.Combine(

--- a/tests/PepperDash.Essentials.DM.Tests.csproj
+++ b/tests/PepperDash.Essentials.DM.Tests.csproj
@@ -19,4 +19,9 @@
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Builds the plugin before tests run; DLL is loaded via MetadataLoadContext, not referenced. -->
+    <ProjectReference Include="..\src\PepperDash.Essentials.DM.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
 </Project>

--- a/tests/PepperDash.Essentials.DM.Tests.csproj
+++ b/tests/PepperDash.Essentials.DM.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

Migrate PepperDash.Essentials.DM plugin from Essentials v2 (net472) to Essentials v3 (net8).

## Changes

### Project Configuration
- Update TargetFramework from net472 to net8
- Update PepperDashEssentials NuGet from 2.7.0 to 3.0.0-dev-v3-testing.13
- Remove obsolete framework references
- Bump version to 3.0.0-local

### Breaking API Fixes
- Change CustomActivate() from public to protected override in 11 device classes
- Replace eRoutingSignalType.UsbInput/UsbOutput with eRoutingSignalType.Usb
- Replace eRoutingSignalType.SecondaryAudio with eRoutingSignalType.AudioVideo
- Add IKeyName/IKeyed implementation to DmpsAudioOutput and DmCardAudioOutputController

### Bug Fixes
- **fix: KeyNotFoundException in LinkHdmiInputToApi** (resolves #33) — Direct dictionary access on `PropertiesConfig.InputSlotSupportsHdcp2[ioSlot]` threw when config entries were missing for HDMI input slots. Replaced with `TryGetValue` (defaulting to `false`), consistent with the pattern already used in `LinkBasicTxToApi`. Added `ContainsKey` guard for `InputCardHdcpStateFeedbacks`.

### New Feature: HD-MD-NxM-4KZ-E Switcher Support (`938e842`)
- **New `HdMdNxM4kzEController`** — Standalone bridgeable controller for the 4KZ-E switcher family, implementing `IRoutingNumericWithFeedback` and `IHasFeedback`
- **Supported models**: HdMd4x14kzE, HdMd4x24kzE, HdMd4x44kzE, HdMd8x44kzE, HdMd8x84kzE (factory type names: `hdmd4x14kze`, `hdmd4x24kze`, `hdmd4x44kze`, `hdmd8x44kze`, `hdmd8x84kze`)
- **Key design decision**: New standalone class rather than modifying existing `HdMdNxM4kEBridgeableController` — the 4KZ-E models have a different Crestron SDK type hierarchy (`HdMdNxM4kzE` base vs `HdMdNxM`), different constructors (2-arg, no IP address), and different input/output types (`HdMdNxM4kzEHdmiInput`/`HdMdNxM4kzEHdmiOutput`)
- **Fixes feedback bug** from previous `add-hdmdNxM4kze-support` branch where switching worked but feedback didn't — root cause was casting to wrong types (`HdMdNxMHdmiInput` instead of `HdMdNxM4kzEHdmiInput`)
- **New `HdMdNxM4kzEPropertiesConfig`** config class with `Control`, `Inputs`, `Outputs` properties
- Reuses existing `HdMdNxM4kEControllerJoinMap` from Essentials Core
- Feedbacks: VideoInputSync, VideoOutputRoute, InputName, OutputName, OutputRouteName, InputHdcpEnable, DeviceName, AutoRoute
- **Tests updated**: Factory count 12→13, 5 new type name metadata tests, config deserialization tests (84 total tests passing)

### Code Cleanup
- Remove unused Crestron.SimplSharp.Reflection import
- Replace Debug.Console with Debug.LogInformation
- Update MinimumEssentialsFrameworkVersion to 3.0.0 in all factories (now 13 total)

### Testing Checklist
- [x] Solution builds without errors targeting net8
- [x] CPLZ package generates correctly
- [x] Zero remaining Debug.Console calls (except 3 commented-out)
- [x] Zero SERIES3/SERIES4 references
- [x] Zero SimplSharp.Reflection references
- [x] All MinimumEssentialsFrameworkVersion set to 3.0.0
- [x] Plugin loads in Essentials v3 runtime on RMC4
- [x] DM-MD-8x8 chassis registers successfully (IP-ID 0x80)
- [x] EISC bridge links all 28 join attributes without error
- [x] Video/audio routing confirmed (Input 6→Out 1, Input 3→Out 5, Input 6→Out 2)
- [x] Resolution feedback working (Input 1: 1920x1080@60Hz)
- [x] HDCP events firing on all applicable inputs
- [x] AudioBreakaway/USBBreakaway feedback operational
- [x] All 84 unit tests pass (0 failed, 0 skipped)
- [ ] HD-MD-NxM-4KZ-E hardware deployment validation

BREAKING CHANGE: Plugin now targets net8 and requires Essentials v3. Not compatible with Essentials v2 (net472) runtime.