### PR TITLE
fix: implement IKeyed/IKeyName on volume classes to fix plugin load

### DIFF
--- a/src/AirMedia/AirMediaController.cs
+++ b/src/AirMedia/AirMediaController.cs
@@ -371,7 +371,7 @@ namespace PepperDash.Essentials.DM.AirMedia
     {
         public AirMediaControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "2.28.1";
             TypeNames = new List<string>() { "am200", "am300", "am3200" };
         }
 

--- a/src/Chassis/DmBladeChassisController.cs
+++ b/src/Chassis/DmBladeChassisController.cs
@@ -515,7 +515,7 @@ namespace PepperDash.Essentials.DM
         /// </summary>
         void AddVolumeControl(uint number, Audio.Output audio)
         {
-            VolumeControls.Add(number, new DmCardAudioOutputController(audio));
+            VolumeControls.Add(number, new DmCardAudioOutputController(string.Format("{0}-audioOutput{1}", Key, number), string.Format("{0} Audio Output {1}", Name, number), audio));
         }
 
         //public void SetInputHdcpSupport(uint input, ePdtHdcpSupport hdcpSetting)

--- a/src/Chassis/DmCardAudioOutput.cs
+++ b/src/Chassis/DmCardAudioOutput.cs
@@ -12,6 +12,10 @@ namespace PepperDash.Essentials.DM
 {
     public class DmCardAudioOutputController : IBasicVolumeWithFeedback
     {
+        public string Key { get; private set; }
+
+        public string Name { get; private set; }
+
         public Audio.Output Output { get; private set; }
 
         public IntFeedback VolumeLevelFeedback { get; private set; }
@@ -21,8 +25,10 @@ namespace PepperDash.Essentials.DM
         ushort PreMuteVolumeLevel;
         bool IsMuted;
 
-        public DmCardAudioOutputController(Audio.Output output)
+        public DmCardAudioOutputController(string key, string name, Audio.Output output)
         {
+            Key = key;
+            Name = name;
             Output = output;
             VolumeLevelFeedback = new IntFeedback(() => Output.VolumeFeedback.UShortValue);
             MuteFeedback = new BoolFeedback(() => IsMuted);

--- a/src/Chassis/DmChassisController.cs
+++ b/src/Chassis/DmChassisController.cs
@@ -1044,7 +1044,7 @@ namespace PepperDash.Essentials.DM
         /// </summary>
         void AddVolumeControl(uint number, Audio.Output audio)
         {
-            VolumeControls.Add(number, new DmCardAudioOutputController(audio));
+            VolumeControls.Add(number, new DmCardAudioOutputController(string.Format("{0}-audioOutput{1}", Key, number), string.Format("{0} Audio Output {1}", Name, number), audio));
         }
 
         //public void SetInputHdcpSupport(uint input, ePdtHdcpSupport hdcpSetting)
@@ -2210,7 +2210,7 @@ namespace PepperDash.Essentials.DM
     {
         public DmChassisControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "2.28.1";
             TypeNames = new List<string>() { "dmmd8x8", "dmmd8x8rps", "dmmd8x8cpu3", "dmmd8x8cpu3rps", 
                 "dmmd16x16", "dmmd16x16rps", "dmmd16x16cpu3", "dmmd16x16cpu3rps", 
                 "dmmd32x32", "dmmd32x32rps", "dmmd32x32cpu3", "dmmd32x32cpu3rps", 

--- a/src/Chassis/DmpsAudioOutputController.cs
+++ b/src/Chassis/DmpsAudioOutputController.cs
@@ -31,16 +31,16 @@ namespace PepperDash.Essentials.DM
         {
             card.BaseDevice.DMOutputChange += new DMOutputEventHandler(BaseDevice_DMOutputChange);
             var output = new Dmps3AudioOutputWithMixerBase(stream);
-            MasterVolumeLevel = new DmpsAudioOutputWithMixer(output, eDmpsLevelType.Master);
-            SourceVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Source);
+            MasterVolumeLevel = new DmpsAudioOutputWithMixer(key, output, eDmpsLevelType.Master);
+            SourceVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Source);
         }
         public DmpsAudioOutputController(string key, string name, DMOutput card, Card.Dmps3DmHdmiAudioOutput.Dmps3DmHdmiOutputStream stream)
             : base(key, name)
         {
             card.BaseDevice.DMOutputChange += new DMOutputEventHandler(BaseDevice_DMOutputChange);
             var output = new Dmps3AudioOutputWithMixerBase(stream);
-            MasterVolumeLevel = new DmpsAudioOutputWithMixer(output, eDmpsLevelType.Master);
-            SourceVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Source);
+            MasterVolumeLevel = new DmpsAudioOutputWithMixer(key, output, eDmpsLevelType.Master);
+            SourceVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Source);
         }
 
         public DmpsAudioOutputController(string key, string name, Card.Dmps3OutputBase card)
@@ -52,53 +52,53 @@ namespace PepperDash.Essentials.DM
             {
                 var programOutput = card as Card.Dmps3ProgramOutput;
                 var output = new Dmps3AudioOutputWithMixerBase(card, programOutput.OutputMixer);
-                MasterVolumeLevel = new DmpsAudioOutputWithMixerAndEq(output, eDmpsLevelType.Master, programOutput.OutputEqualizer);
-                SourceVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Source);
-                MicsMasterVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.MicsMaster);
-                Codec1VolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Codec1);
-                Codec2VolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Codec2);
+                MasterVolumeLevel = new DmpsAudioOutputWithMixerAndEq(key, output, eDmpsLevelType.Master, programOutput.OutputEqualizer);
+                SourceVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Source);
+                MicsMasterVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.MicsMaster);
+                Codec1VolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Codec1);
+                Codec2VolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Codec2);
             }
             else if (card is Card.Dmps3Aux1Output)
             {
                 var auxOutput = card as Card.Dmps3Aux1Output;
                 var output = new Dmps3AudioOutputWithMixerBase(card, auxOutput.OutputMixer);
-                MasterVolumeLevel = new DmpsAudioOutputWithMixerAndEq(output, eDmpsLevelType.Master, auxOutput.OutputEqualizer);
-                SourceVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Source);
-                MicsMasterVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.MicsMaster);
-                Codec2VolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Codec2);
+                MasterVolumeLevel = new DmpsAudioOutputWithMixerAndEq(key, output, eDmpsLevelType.Master, auxOutput.OutputEqualizer);
+                SourceVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Source);
+                MicsMasterVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.MicsMaster);
+                Codec2VolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Codec2);
             }
             else if (card is Card.Dmps3Aux2Output)
             {
                 var auxOutput = card as Card.Dmps3Aux2Output;
                 var output = new Dmps3AudioOutputWithMixerBase(card, auxOutput.OutputMixer);
-                MasterVolumeLevel = new DmpsAudioOutputWithMixerAndEq(output, eDmpsLevelType.Master, auxOutput.OutputEqualizer);
-                SourceVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Source);
-                MicsMasterVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.MicsMaster);
-                Codec1VolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Codec1);
+                MasterVolumeLevel = new DmpsAudioOutputWithMixerAndEq(key, output, eDmpsLevelType.Master, auxOutput.OutputEqualizer);
+                SourceVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Source);
+                MicsMasterVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.MicsMaster);
+                Codec1VolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Codec1);
             }
             else if (card is Card.Dmps3DigitalMixOutput)
             {
                 var mixOutput = card as Card.Dmps3DigitalMixOutput;
                 var output = new Dmps3AudioOutputWithMixerBase(card, mixOutput.OutputMixer);
-                MasterVolumeLevel = new DmpsAudioOutputWithMixer(output, eDmpsLevelType.Master);
-                SourceVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Source);
-                MicsMasterVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.MicsMaster);
+                MasterVolumeLevel = new DmpsAudioOutputWithMixer(key, output, eDmpsLevelType.Master);
+                SourceVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Source);
+                MicsMasterVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.MicsMaster);
             }
             else if (card is Card.Dmps3HdmiOutput)
             {
                 var hdmiOutput = card as Card.Dmps3HdmiOutput;
                 var output = new Dmps3AudioOutputWithMixerBase(card, hdmiOutput.OutputMixer);
-                MasterVolumeLevel = new DmpsAudioOutputWithMixer(output, eDmpsLevelType.Master);
-                SourceVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Source);
-                MicsMasterVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.MicsMaster);
+                MasterVolumeLevel = new DmpsAudioOutputWithMixer(key, output, eDmpsLevelType.Master);
+                SourceVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Source);
+                MicsMasterVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.MicsMaster);
             }
             else if (card is Card.Dmps3DmOutput)
             {
                 var dmOutput = card as Card.Dmps3DmOutput;
                 var output = new Dmps3AudioOutputWithMixerBase(card, dmOutput.OutputMixer);
-                MasterVolumeLevel = new DmpsAudioOutputWithMixer(output, eDmpsLevelType.Master);
-                SourceVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.Source);
-                MicsMasterVolumeLevel = new DmpsAudioOutput(output, eDmpsLevelType.MicsMaster);
+                MasterVolumeLevel = new DmpsAudioOutputWithMixer(key, output, eDmpsLevelType.Master);
+                SourceVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.Source);
+                MicsMasterVolumeLevel = new DmpsAudioOutput(key, output, eDmpsLevelType.MicsMaster);
             }
         }
 
@@ -278,8 +278,8 @@ namespace PepperDash.Essentials.DM
     public class DmpsAudioOutputWithMixerAndEq : DmpsAudioOutputWithMixer
     {
         private CrestronControlSystem.Dmps3OutputEqualizer Eq;
-        public DmpsAudioOutputWithMixerAndEq(Dmps3AudioOutputWithMixerBase output, eDmpsLevelType type, CrestronControlSystem.Dmps3OutputEqualizer eq)
-            : base(output, type)
+        public DmpsAudioOutputWithMixerAndEq(string key, Dmps3AudioOutputWithMixerBase output, eDmpsLevelType type, CrestronControlSystem.Dmps3OutputEqualizer eq)
+            : base(key, output, type)
         {
             Eq = eq;
         }
@@ -295,8 +295,8 @@ namespace PepperDash.Essentials.DM
     {
         Dmps3AudioOutputWithMixerBase Output;
 
-        public DmpsAudioOutputWithMixer(Dmps3AudioOutputWithMixerBase output, eDmpsLevelType type)
-            : base(output, type)
+        public DmpsAudioOutputWithMixer(string key, Dmps3AudioOutputWithMixerBase output, eDmpsLevelType type)
+            : base(key, output, type)
         {
             Output = output;
             GetVolumeMax();
@@ -353,6 +353,8 @@ namespace PepperDash.Essentials.DM
         protected short MaxLevel { get; set; }
 
         public eDmpsLevelType Type { get; private set; }
+        public string Key { get; private set; }
+        public string Name { get; private set; }
         public BoolFeedback MuteFeedback { get; private set; }
         public IntFeedback VolumeLevelFeedback { get; private set; }
         public IntFeedback VolumeLevelScaledFeedback { get; private set; }
@@ -362,8 +364,10 @@ namespace PepperDash.Essentials.DM
         Action<bool> VolumeUpAction;
         Action<bool> VolumeDownAction;
 
-        public DmpsAudioOutput(Dmps3AudioOutputBase output, eDmpsLevelType type)
+        public DmpsAudioOutput(string key, Dmps3AudioOutputBase output, eDmpsLevelType type)
         {
+            Key = string.Format("{0}-{1}", key, type);
+            Name = Key;
             VolumeLevelInput = 0;
             EnableVolumeSend = false;
             Type = type;

--- a/src/Chassis/DmpsRoutingController.cs
+++ b/src/Chassis/DmpsRoutingController.cs
@@ -978,7 +978,7 @@ namespace PepperDash.Essentials.DM
         /// </summary>
         void AddVolumeControl(uint number, Audio.Output audio)
         {
-            VolumeControls.Add(number, new DmCardAudioOutputController(audio));
+            VolumeControls.Add(number, new DmCardAudioOutputController(string.Format("{0}-audioOutput{1}", Key, number), string.Format("{0} Audio Output {1}", Name, number), audio));
         }
 
         void Dmps_DMInputChange(Switch device, DMInputEventArgs args)

--- a/src/Chassis/HdMd8xNController.cs
+++ b/src/Chassis/HdMd8xNController.cs
@@ -486,7 +486,7 @@ namespace PepperDash.Essentials.DM.Chassis
 		{
 			public HdMd8xNControllerFactory()
 			{
-                MinimumEssentialsFrameworkVersion = "2.4.5";
+                MinimumEssentialsFrameworkVersion = "2.28.1";
                 TypeNames = new List<string>() { "hdmd8x2", "hdmd8x1" };
 			}
 

--- a/src/Chassis/HdMdNxM4kEBridgeableController.cs
+++ b/src/Chassis/HdMdNxM4kEBridgeableController.cs
@@ -467,7 +467,7 @@ namespace PepperDash.Essentials.DM.Chassis
 		{
 			public HdMdNxM4kEControllerFactory()
 			{
-                MinimumEssentialsFrameworkVersion = "2.4.5";
+                MinimumEssentialsFrameworkVersion = "2.28.1";
                 TypeNames = new List<string>() { "hdmd4x14ke-bridgeable", "hdmd4x24ke", "hdmd6x24ke" };
 			}
 

--- a/src/Chassis/HdPsXxxController.cs
+++ b/src/Chassis/HdPsXxxController.cs
@@ -521,7 +521,7 @@ Selector: {4}
     {
         public HdSp401ControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "2.28.1";
             
             TypeNames = new List<string>() { "hdps401", "hdps402", "hdps621", "hdps622" };
         }

--- a/src/DmLite/HdMdxxxCEController.cs
+++ b/src/DmLite/HdMdxxxCEController.cs
@@ -283,7 +283,7 @@ namespace PepperDash.Essentials.DM
     {
         public HdMdxxxCEControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "2.28.1";
             TypeNames = new List<string>() { "hdmd400ce", "hdmd300ce", "hdmd200ce", "hdmd200c1ge"};
         }
 

--- a/src/Endpoints/DGEs/Dge100Controller.cs
+++ b/src/Endpoints/DGEs/Dge100Controller.cs
@@ -263,7 +263,7 @@ namespace PepperDash.Essentials.DM.Endpoints.DGEs
     {
         public Dge100ControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "2.28.1";
             TypeNames = new List<string>() { "dge100" };
         }
 

--- a/src/Endpoints/DGEs/DmDge200CController.cs
+++ b/src/Endpoints/DGEs/DmDge200CController.cs
@@ -61,7 +61,7 @@ namespace PepperDash.Essentials.DM.Endpoints.DGEs
 	{
 		public DmDge200CControllerFactory()
 		{
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "2.28.1";
             TypeNames = new List<string>() { "dmdge200c" };
 		}
 

--- a/src/Endpoints/Receivers/DmRmcHelper.cs
+++ b/src/Endpoints/Receivers/DmRmcHelper.cs
@@ -608,7 +608,7 @@ namespace PepperDash.Essentials.DM
     {
         public DmRmcControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "2.28.1";
             TypeNames = new List<string>
             { "hdbasetrx", "dmrmc4k100c1g", "dmrmc100c", "dmrmc100s", "dmrmc4k100c", "dmrmc150s",
                 "dmrmc200c", "dmrmc200s", "dmrmc200s2", "dmrmcscalerc", "dmrmcscalers", "dmrmcscalers2", "dmrmc4kscalerc", "dmrmc4kscalercdsp",

--- a/src/Endpoints/Transmitters/DmTxHelpers.cs
+++ b/src/Endpoints/Transmitters/DmTxHelpers.cs
@@ -490,7 +490,7 @@ namespace PepperDash.Essentials.DM
     {
         public DmTxControllerFactory()
         {
-            MinimumEssentialsFrameworkVersion = "2.4.5";
+            MinimumEssentialsFrameworkVersion = "2.28.1";
             TypeNames = new List<string>
             {
                 "dmtx200c",

--- a/src/PepperDash.Essentials.DM.csproj
+++ b/src/PepperDash.Essentials.DM.csproj
@@ -27,7 +27,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="PepperDashEssentials" Version="2.7.0">
+    <PackageReference Include="PepperDashEssentials" Version="2.39.0">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/src/VideoWindowing/HdWp4k401cController.cs
+++ b/src/VideoWindowing/HdWp4k401cController.cs
@@ -412,7 +412,7 @@ namespace PepperDash.Essentials.DM.VideoWindowing
         {
             public HdWp4k401cControllerFactory()
             {
-                MinimumEssentialsFrameworkVersion = "2.4.5";
+                MinimumEssentialsFrameworkVersion = "2.28.1";
                 TypeNames = new List<string>() { "hdWp4k401c" };
             }
 


### PR DESCRIPTION
Essentials 2.28.1 added IKeyed and IKeyName to IBasicVolumeWithFeedback. DmpsAudioOutput and DmCardAudioOutputController did not implement Key or Name, so Mono vtable setup failed at type load and the plugin loader logged errors for DmpsAudioOutput, DmpsAudioOutputWithMixer, and DmpsAudioOutputWithMixerAndEq on every processor.

Add Key/Name to both classes, thread a key through the DmpsAudioOutput hierarchy and its call sites, bump PepperDashEssentials to 2.39.0, and raise MinimumEssentialsFrameworkVersion to 2.28.1 across the factories.